### PR TITLE
fix: outdent indented numbered-list items (3 tutorials)

### DIFF
--- a/tutorials/abap-environment-create-cds-mde/abap-environment-create-cds-mde.md
+++ b/tutorials/abap-environment-create-cds-mde/abap-environment-create-cds-mde.md
@@ -46,7 +46,7 @@ For more information on creating a read-only app, see the SAP Help Portal: [Deve
     <!-- border -->
     ![step1a-new-package](step1a-new-package.png)
 
-    2. Enter the following then follow the wizard, choosing a **new** transport request:
+2. Enter the following then follow the wizard, choosing a **new** transport request:
     - Name: **`Z_ENHANCE_CDS_###`**
     - Description **Enhance CDS Tutorial 2020**
 
@@ -63,7 +63,7 @@ For more information on creating a read-only app, see the SAP Help Portal: [Deve
     <!-- border -->
     ![step2a-new-cds](step2a-new-cds.png)
 
-    2. Add the following:
+2. Add the following:
         - Name: **`Z_I_TRAVEL_R_###`**
         - Description: **`Travel Model View Entity - Read Only`**
         - Referenced object: **`/DMO/I_TRAVEL_U`**

--- a/tutorials/abap-environment-create-rap-business-events/abap-environment-create-rap-business-events.md
+++ b/tutorials/abap-environment-create-rap-business-events/abap-environment-create-rap-business-events.md
@@ -54,7 +54,7 @@ To produce and raise an event you need first to define your RAP Business Object 
       <!-- border -->
       ![step1c-new-tr](step1c-new-tr.png)
 
-  3. Select your package and choose **New > Other Repository object > Database table** from the context menu. Enter the following.
+3. Select your package and choose **New > Other Repository object > Database table** from the context menu. Enter the following.
 
       - Name: `ZONLINESHOP_###`
       - Description: `Database table for Online Shop`
@@ -63,7 +63,7 @@ To produce and raise an event you need first to define your RAP Business Object 
       ![step1d-create-db-table](step1d-create-db-table.png)
 
 
-  4. Copy the code below to the Database and replace `###` with your number. 
+4. Copy the code below to the Database and replace `###` with your number. 
       
   > You need the Admin field(s) for `local_last_changed` and `last_changed` in the table, in order to use the ABAP Repository Objects Generator later. These fields are used to provide optimistic concurrency control, using ETags. For more information, see: [ETag Definition | SAP Help](https://help.sap.com/docs/ABAP_PLATFORM_NEW/fc4c71aa50014fd1b43721701471913d/74b16803910d4939a83f354259fca4fc.html)
 

--- a/tutorials/abap-environment-extend-cds-view/abap-environment-extend-cds-view.md
+++ b/tutorials/abap-environment-extend-cds-view/abap-environment-extend-cds-view.md
@@ -126,7 +126,7 @@ Create a database table to store the Travel data. This Travel table contains `Tr
     }
     ```
 
-  6. Save ![save icon](save.png) and activate ![activate icon](activate.png) the changes.
+6. Save ![save icon](save.png) and activate ![activate icon](activate.png) the changes.
 
 ### Create data generator class
 


### PR DESCRIPTION
## Summary

Outdents 5 numbered-list items across 3 tutorials so they sit flush with their sibling `1.` (or `5.`) instead of being interpreted by CommonMark as nested `<ol start="N">` items. Detected by [`tutorials-ims/scripts/lint-tutorial-markdown.ts`](https://github.com/sap-tutorials/tutorials-ims/blob/main/scripts/lint-tutorial-markdown.ts) and tracked in [tutorials-ims#193](https://github.com/sap-tutorials/tutorials-ims/issues/193).

This repo's `abap-environment-create-cds-mde` tutorial was the **original report** in [tutorials-ims#168](https://github.com/sap-tutorials/tutorials-ims/issues/168) — the layout glitch that triggered the platform-side fix and the author-side lint.

## Changes (3 tutorials)

| Tutorial | Lines | Fix |
|---|---|---|
| `abap-environment-create-cds-mde` | L49, L66 | Outdent `2.` from 4-space indent to flush-left (matches sibling `1.`) |
| `abap-environment-create-rap-business-events` | L57, L66 | Outdent `3.` and `4.` from 2-space indent to flush-left |
| `abap-environment-extend-cds-view` | L129 | Outdent `6.` from 2-space indent to flush-left (matches siblings 1-5) |

Per-edit verification: each numbered marker is now flush with its `1.` (or matching) sibling. CommonMark continuation content (images, prose, sub-bullets) within each item retains its existing indent so it remains attached to the right list item.

## How it was rendered before vs after

**Before** (CommonMark interpretation):
```
1. Create a new package
   ![image]
    2. Enter the following:    ← Renders as a NEW <ol start="2">
       - Name: ...
```

**After**:
```
1. Create a new package
   ![image]
2. Enter the following:        ← Continuation of the same list
   - Name: ...
```

## Verification

Run [`lint-tutorial-markdown`](https://github.com/sap-tutorials/tutorials-ims/blob/main/scripts/lint-tutorial-markdown.ts) against a fresh `.tutorial-cache/` after merge — these 3 tutorials should drop off the report.

## Related

- Platform-side fix: [tutorials-ims#190](https://github.com/sap-tutorials/tutorials-ims/pull/190) (merged)
- Author-side lint: [tutorials-ims#191](https://github.com/sap-tutorials/tutorials-ims/pull/191) (merged)
- Original report: [tutorials-ims#168](https://github.com/sap-tutorials/tutorials-ims/issues/168) (closed) — flagged this repo's `abap-environment-create-cds-mde`
- Tracking: [tutorials-ims#193](https://github.com/sap-tutorials/tutorials-ims/issues/193)
