### PR TITLE
Publish tutorial: abap-s4hanacloud-purchasereq-provide-authorization

### DIFF
--- a/tutorials/abap-s4hanacloud-purchasereq-integrate-wrapper/abap-s4hanacloud-purchasereq-integrate-wrapper.md
+++ b/tutorials/abap-s4hanacloud-purchasereq-integrate-wrapper/abap-s4hanacloud-purchasereq-integrate-wrapper.md
@@ -3,8 +3,8 @@ auto_validation: true
 time: 15
 tags: [ tutorial>intermediate, software-product>sap-s-4hana, programming-tool>abap-development, programming-tool>abap-extensibility]
 primary_tag: programming-tool>abap-extensibility
-author_name: Achim Seubert
-author_profile: https://github.com/AchimSeubert
+author_name: Matthäus Schüle
+author_profile: https://github.com/MatthaeusSchuele
 parser: v2
 ---
 

--- a/tutorials/abap-s4hanacloud-purchasereq-provide-authorization/abap-s4hanacloud-purchasereq-provide-authorization.md
+++ b/tutorials/abap-s4hanacloud-purchasereq-provide-authorization/abap-s4hanacloud-purchasereq-provide-authorization.md
@@ -3,8 +3,8 @@ auto_validation: true
 time: 15
 tags: [ tutorial>intermediate, software-product>sap-s-4hana, programming-tool>abap-development, programming-tool>abap-extensibility]
 primary_tag: programming-tool>abap-extensibility
-author_name: Achim Seubert
-author_profile: https://github.com/AchimSeubert
+author_name: Matthäus Schüle
+author_profile: https://github.com/MatthaeusSchuele
 parser: v2
 ---
 

--- a/tutorials/abap-s4hanacloud-purchasereq-replace-wrapper/abap-s4hanacloud-purchasereq-replace-wrapper.md
+++ b/tutorials/abap-s4hanacloud-purchasereq-replace-wrapper/abap-s4hanacloud-purchasereq-replace-wrapper.md
@@ -3,8 +3,8 @@ auto_validation: true
 time: 20
 tags: [ tutorial>intermediate, software-product>sap-s-4hana, programming-tool>abap-development, programming-tool>abap-extensibility]
 primary_tag: programming-tool>abap-extensibility
-author_name: Achim Seubert
-author_profile: https://github.com/AchimSeubert
+author_name: Matthäus Schüle
+author_profile: https://github.com/MatthaeusSchuele
 parser: v2
 ---
 


### PR DESCRIPTION
Publish tutorial: abap-s4hanacloud-purchasereq-provide-authorization

    Promote tutorial from QA to Production repository.

    Tutorial Details:
    - Slug: abap-s4hanacloud-purchasereq-provide-authorization
    - Source: QA Repository (-Contribution)
    - Target: Production Repository

    This PR was created automatically by the Sage VS Code Extension.