### PR TITLE
Fix malformed markdown at source (#1963) (batch 5/5)

### DIFF
--- a/tutorials/abap-s4hanacloud-procurement-purchasereq-shop/abap-s4hanacloud-procurement-purchasereq-shop.md
+++ b/tutorials/abap-s4hanacloud-procurement-purchasereq-shop/abap-s4hanacloud-procurement-purchasereq-shop.md
@@ -92,35 +92,35 @@ In this tutorial, wherever ### appears, use a number (e.g. 000). This tutorial i
 
   5. Replace your code with following:
 
-    ```ABAP
-    @EndUserText.label : 'Shopping cart table'
-    @AbapCatalog.enhancement.category : #NOT_EXTENSIBLE
-    @AbapCatalog.tableCategory : #TRANSPARENT
-    @AbapCatalog.deliveryClass : #A
-    @AbapCatalog.dataMaintenance : #RESTRICTED
-    define table zashopcart_### {
-    key client            : abap.clnt not null;
-    key order_uuid        : sysuuid_x16 not null;
-    order_id              : abap.numc(8) not null;
-    ordered_item          : abap.char(40) not null;
-    @Semantics.amount.currencyCode : 'zashopcart_###.currency'
-    price                 : abap.curr(11,2);
-    @Semantics.amount.currencyCode : 'zashopcart_###.currency'
-    total_price           : abap.curr(11,2);
-    currency              : abap.cuky;
-    order_quantity        : abap.numc(4);
-    delivery_date         : abap.dats;
-    overall_status        : abap.char(30);
-    notes                 : abap.string(256);
-    created_by            : abp_creation_user;
-    created_at            : abp_creation_tstmpl;
-    last_changed_by       : abp_lastchange_user;
-    last_changed_at       : abp_lastchange_tstmpl;
-    local_last_changed_at : abp_locinst_lastchange_tstmpl;
-    purchase_requisition  : abap.char(10);
-    pr_creation_date      : abap.dats;
-    }
-    ```
+   ```ABAP
+   @EndUserText.label : 'Shopping cart table'
+   @AbapCatalog.enhancement.category : #NOT_EXTENSIBLE
+   @AbapCatalog.tableCategory : #TRANSPARENT
+   @AbapCatalog.deliveryClass : #A
+   @AbapCatalog.dataMaintenance : #RESTRICTED
+   define table zashopcart_### {
+   key client            : abap.clnt not null;
+   key order_uuid        : sysuuid_x16 not null;
+   order_id              : abap.numc(8) not null;
+   ordered_item          : abap.char(40) not null;
+   @Semantics.amount.currencyCode : 'zashopcart_###.currency'
+   price                 : abap.curr(11,2);
+   @Semantics.amount.currencyCode : 'zashopcart_###.currency'
+   total_price           : abap.curr(11,2);
+   currency              : abap.cuky;
+   order_quantity        : abap.numc(4);
+   delivery_date         : abap.dats;
+   overall_status        : abap.char(30);
+   notes                 : abap.string(256);
+   created_by            : abp_creation_user;
+   created_at            : abp_creation_tstmpl;
+   last_changed_by       : abp_lastchange_user;
+   last_changed_at       : abp_lastchange_tstmpl;
+   local_last_changed_at : abp_locinst_lastchange_tstmpl;
+   purchase_requisition  : abap.char(10);
+   pr_creation_date      : abap.dats;
+   }
+   ```
 
    6. Save and activate.
 
@@ -148,22 +148,22 @@ In this tutorial, wherever ### appears, use a number (e.g. 000). This tutorial i
      **Please note**: Error Invalid XML format.   
      If you receive an error message **Invalid XML format of the response**, this may be due to a bug in version 1.26 of the ADT tools. An update of your ADT plugin to version 1.26.3 will fix this issue.
 
-    | **RAP Layer**                          | **Artefacts**           | **Artefact Names**                                  |
-    |----------------------------------------|-------------------------|-----------------------------------------------------|
-    | **Business Object**                    |                         |                                                     |
-    |                                        | **Data Model**          | Data Definition Name: **`ZR_SHOPCARTTP_###`**     |
-    |                                        |                         | Alias Name: **`ShoppingCart`**                        |  
-    |                                        | **Behavior**            | Implementation Class: **`ZBP_SHOPCARTTP_###`**    |
-    |                                        |                         | Draft Table Name: **`ZDSHOPCART_###`**            |  
-    | **Service Projection (BO Projection)** |                         | Name: **`ZC_SHOPCARTTP_###`**                     |
-    | **Business Services**                  |                         |                                                     |
-    |                                        | **Service Definition**  | Name: **`ZUI_SHOPCART_###`**                      |
-    |                                        | **Service Binding**     | Name: **`ZUI_SHOPCART_O4_###`**                   |
-    |                                        |                         | Binding Type: **`OData V4 - UI`**                   |
+   | **RAP Layer**                          | **Artefacts**           | **Artefact Names**                                  |
+   |----------------------------------------|-------------------------|-----------------------------------------------------|
+   | **Business Object**                    |                         |                                                     |
+   |                                        | **Data Model**          | Data Definition Name: **`ZR_SHOPCARTTP_###`**     |
+   |                                        |                         | Alias Name: **`ShoppingCart`**                        |  
+   |                                        | **Behavior**            | Implementation Class: **`ZBP_SHOPCARTTP_###`**    |
+   |                                        |                         | Draft Table Name: **`ZDSHOPCART_###`**            |  
+   | **Service Projection (BO Projection)** |                         | Name: **`ZC_SHOPCARTTP_###`**                     |
+   | **Business Services**                  |                         |                                                     |
+   |                                        | **Service Definition**  | Name: **`ZUI_SHOPCART_###`**                      |
+   |                                        | **Service Binding**     | Name: **`ZUI_SHOPCART_O4_###`**                   |
+   |                                        |                         | Binding Type: **`OData V4 - UI`**                   |
 
-    ![cds](generator3.png)                    
+   ![cds](generator3.png)                    
 
-    Click **Next >**.
+   Click **Next >**.
 
   4. Click **Finish**.
 
@@ -177,77 +177,77 @@ In this tutorial, wherever ### appears, use a number (e.g. 000). This tutorial i
   
   1. Open your behavior definition **`ZR_SHOPCARTTP_###`** to enhance it. Add the following read-only fields to your behavior definition:
 
-    ```ABAP
-    ,
-    PurchaseRequisition,
-    PrCreationDate,
-    DeliveryDate;
-    ```
+   ```ABAP
+   ,
+   PurchaseRequisition,
+   PrCreationDate,
+   DeliveryDate;
+   ```
 
-     ![projection](bdef3x.png)
+   ![projection](bdef3x.png)
 
 
   2. Check your behavior definition:
 
-    ```ABAP
-    managed implementation in class ZBP_SHOPCARTTP_### unique;
-    strict ( 2 );
-    with draft;
+   ```ABAP
+   managed implementation in class ZBP_SHOPCARTTP_### unique;
+   strict ( 2 );
+   with draft;
 
-    define behavior for ZR_SHOPCARTTP_### alias ShoppingCart
-    persistent table zashopcart_###
-    draft table ZDSHOPCART_###
-    etag master LocalLastChangedAt
-    lock master total etag LastChangedAt
-    authorization master( global )
+   define behavior for ZR_SHOPCARTTP_### alias ShoppingCart
+   persistent table zashopcart_###
+   draft table ZDSHOPCART_###
+   etag master LocalLastChangedAt
+   lock master total etag LastChangedAt
+   authorization master( global )
 
-    {
-    field ( readonly )
-       OrderUUID,
-       CreatedAt,
-       CreatedBy,
-       LastChangedAt,
-       LastChangedBy,
-       LocalLastChangedAt,
-       PurchaseRequisition,
-       PrCreationDate,
-       DeliveryDate;
+   {
+   field ( readonly )
+      OrderUUID,
+      CreatedAt,
+      CreatedBy,
+      LastChangedAt,
+      LastChangedBy,
+      LocalLastChangedAt,
+      PurchaseRequisition,
+      PrCreationDate,
+      DeliveryDate;
 
-    field ( numbering : managed )
-       OrderUUID;
+   field ( numbering : managed )
+      OrderUUID;
 
-    create;
-    update;
-    delete;
+   create;
+   update;
+   delete;
 
-    draft action Edit;
-    draft action Activate;
-    draft action Discard;
-    draft action Resume;
-    draft determine action Prepare;
+   draft action Edit;
+   draft action Activate;
+   draft action Discard;
+   draft action Resume;
+   draft determine action Prepare;
 
-    mapping for ZASHOPCART_###
-    {
-       OrderUUID = ORDER_UUID;
-       OrderID = ORDER_ID;
-       OrderedItem = ORDERED_ITEM;
-       Price = PRICE;
-       TotalPrice = TOTAL_PRICE;
-       Currency = CURRENCY;
-       OrderQuantity = ORDER_QUANTITY;
-       DeliveryDate = DELIVERY_DATE;
-       OverallStatus = OVERALL_STATUS;
-       Notes = NOTES;
-       CreatedBy = CREATED_BY;
-       CreatedAt = CREATED_AT;
-       LastChangedBy = LAST_CHANGED_BY;
-       LastChangedAt = LAST_CHANGED_AT;
-       LocalLastChangedAt = LOCAL_LAST_CHANGED_AT;
-       PurchaseRequisition = PURCHASE_REQUISITION;
-       PrCreationDate = PR_CREATION_DATE;
-    } 
-    }       
-    ```
+   mapping for ZASHOPCART_###
+   {
+      OrderUUID = ORDER_UUID;
+      OrderID = ORDER_ID;
+      OrderedItem = ORDERED_ITEM;
+      Price = PRICE;
+      TotalPrice = TOTAL_PRICE;
+      Currency = CURRENCY;
+      OrderQuantity = ORDER_QUANTITY;
+      DeliveryDate = DELIVERY_DATE;
+      OverallStatus = OVERALL_STATUS;
+      Notes = NOTES;
+      CreatedBy = CREATED_BY;
+      CreatedAt = CREATED_AT;
+      LastChangedBy = LAST_CHANGED_BY;
+      LastChangedAt = LAST_CHANGED_AT;
+      LocalLastChangedAt = LOCAL_LAST_CHANGED_AT;
+      PurchaseRequisition = PURCHASE_REQUISITION;
+      PrCreationDate = PR_CREATION_DATE;
+   } 
+   }       
+   ```
 
    3. Save and activate.  
 

--- a/tutorials/abap-s4hanacloud-purchasereq-deploy-ui-tier1/abap-s4hanacloud-purchasereq-deploy-ui-tier1.md
+++ b/tutorials/abap-s4hanacloud-purchasereq-deploy-ui-tier1/abap-s4hanacloud-purchasereq-deploy-ui-tier1.md
@@ -72,7 +72,7 @@ This step is for creating a list report object page. Open Visual Studio Code and
 
      ![object](vs.png)
 
-    >**Hint:** You can find your folder under: `C:\Users\<userid>\projects`.
+   >**Hint:** You can find your folder under: `C:\Users\<userid>\projects`.
 
   2. Select the menu on the top and click **View > Command Palette**.
 
@@ -104,7 +104,7 @@ This step is for creating a list report object page. Open Visual Studio Code and
 
      Click **Next >**.
 
-    >**Hint:** In case of invalid security certificate errors, follow this [link](https://help.sap.com/docs/SAP_FIORI_tools/17d50220bcd848aa854c9c182d65b699/4b318bede7eb4021a8be385c46c74045.html).
+   >**Hint:** In case of invalid security certificate errors, follow this [link](https://help.sap.com/docs/SAP_FIORI_tools/17d50220bcd848aa854c9c182d65b699/4b318bede7eb4021a8be385c46c74045.html).
 
   6. Select your main entity **`ShoppingCart`** and click **Next >**.
 
@@ -127,7 +127,7 @@ This step is for creating a list report object page. Open Visual Studio Code and
 
      The project folder path has a further substructure.
 
-    >**Hint:** Your **module name must** be written in **lowercase letters**.
+   >**Hint:** Your **module name must** be written in **lowercase letters**.
 
   8. Configure deployment:
        - Target: ABAP
@@ -190,7 +190,7 @@ This step describes the deployment of the created application.
 
       When the deployment is successful, you will get these two information back as a result: **deployment successful**.
 
-    >**Hint:** If an error message appears, use the [Environment Check](https://help.sap.com/docs/SAP_FIORI_tools/17d50220bcd848aa854c9c182d65b699/75390cf5d81e43aea5db231ef4225268.html).
+   >**Hint:** If an error message appears, use the [Environment Check](https://help.sap.com/docs/SAP_FIORI_tools/17d50220bcd848aa854c9c182d65b699/75390cf5d81e43aea5db231ef4225268.html).
 
 
 ### Run your application standalone

--- a/tutorials/abap-s4hanacloud-purchasereq-deploy-ui/abap-s4hanacloud-purchasereq-deploy-ui.md
+++ b/tutorials/abap-s4hanacloud-purchasereq-deploy-ui/abap-s4hanacloud-purchasereq-deploy-ui.md
@@ -72,7 +72,7 @@ This step is for creating a list report object page. Open Visual Studio Code and
 
      ![object](vs.png)
 
-    >**Hint:** You can find your folder under: `C:\Users\<userid>\projects`.
+   >**Hint:** You can find your folder under: `C:\Users\<userid>\projects`.
 
   2. Select the menu on the top and click **View > Command Palette**.
 
@@ -104,7 +104,7 @@ This step is for creating a list report object page. Open Visual Studio Code and
 
      Click **Next >**.
 
-    >**Hint:** In case of invalid security certificate errors, follow this [link](https://help.sap.com/docs/SAP_FIORI_tools/17d50220bcd848aa854c9c182d65b699/4b318bede7eb4021a8be385c46c74045.html).
+   >**Hint:** In case of invalid security certificate errors, follow this [link](https://help.sap.com/docs/SAP_FIORI_tools/17d50220bcd848aa854c9c182d65b699/4b318bede7eb4021a8be385c46c74045.html).
 
   6. Select your main entity **`ShoppingCart`** and click **Next >**.
 
@@ -127,7 +127,7 @@ This step is for creating a list report object page. Open Visual Studio Code and
 
      The project folder path has a further substructure.
 
-    >**Hint:** Your **module name must** be written in **lowercase letters**.
+   >**Hint:** Your **module name must** be written in **lowercase letters**.
 
   8. Configure deployment:
        - Target: ABAP
@@ -176,7 +176,7 @@ This step describes the deployment of the created application.
 
       When the deployment is successful, you will get these two information back as a result: **deployment successful**.
 
-    >**Hint:** If an error message appears, use the [Environment Check](https://help.sap.com/docs/SAP_FIORI_tools/17d50220bcd848aa854c9c182d65b699/75390cf5d81e43aea5db231ef4225268.html).
+   >**Hint:** If an error message appears, use the [Environment Check](https://help.sap.com/docs/SAP_FIORI_tools/17d50220bcd848aa854c9c182d65b699/75390cf5d81e43aea5db231ef4225268.html).
 
 
 ### Run your application standalone

--- a/tutorials/abap-s4hanacloud-purchasereq-enhance-shop/abap-s4hanacloud-purchasereq-enhance-shop.md
+++ b/tutorials/abap-s4hanacloud-purchasereq-enhance-shop/abap-s4hanacloud-purchasereq-enhance-shop.md
@@ -39,92 +39,92 @@ In this tutorial, wherever ### appears, use a number (e.g. 000). This tutorial i
 
   1. Open your behavior definition **`ZR_SHOPCARTTP_###`** to enhance it. Add the following statements to your behavior definition:
 
-    ```ABAP
-    update (features: instance);
-    .
-    .
-    draft action(features: instance) Edit;
-    ```
+   ```ABAP
+   update (features: instance);
+   .
+   .
+   draft action(features: instance) Edit;
+   ```
 
-     ![projection](updatenew.png)
+   ![projection](updatenew.png)
 
   2. Replace the following statements to your behavior definition:
 
-    ```ABAP
-    draft determine action Prepare { validation checkOrderedQuantity;  validation checkDeliveryDate;}
-      determination setInitialOrderValues on modify { create; }
-      determination calculateTotalPrice on modify { create; field Price; } 
-      validation checkOrderedQuantity on save { create; field OrderQuantity; }
-      validation checkDeliveryDate on save { create; field DeliveryDate; }
-    ```
+   ```ABAP
+   draft determine action Prepare { validation checkOrderedQuantity;  validation checkDeliveryDate;}
+     determination setInitialOrderValues on modify { create; }
+     determination calculateTotalPrice on modify { create; field Price; } 
+     validation checkOrderedQuantity on save { create; field OrderQuantity; }
+     validation checkDeliveryDate on save { create; field DeliveryDate; }
+   ```
    
-     ![projection](bdef5xx.png) 
+   ![projection](bdef5xx.png) 
  
   3. Check your behavior definition:
 
-    ```ABAP
-    managed implementation in class ZBP_SHOPCARTTP_### unique;
-    strict ( 2 );
-    with draft;
+   ```ABAP
+   managed implementation in class ZBP_SHOPCARTTP_### unique;
+   strict ( 2 );
+   with draft;
 
-    define behavior for ZR_SHOPCARTTP_### alias ShoppingCart
-    persistent table zashopcart_###
-    draft table ZDSHOPCART_###
-    etag master LocalLastChangedAt
-    lock master total etag LastChangedAt
-    authorization master( global )
-    {
-      field ( readonly ) 
-      OrderUUID,
-      CreatedAt,
-      CreatedBy,
-      LastChangedAt,
-      LastChangedBy,
-      LocalLastChangedAt,
-      PurchaseRequisition,
-      PrCreationDate,
-      DeliveryDate;      
+   define behavior for ZR_SHOPCARTTP_### alias ShoppingCart
+   persistent table zashopcart_###
+   draft table ZDSHOPCART_###
+   etag master LocalLastChangedAt
+   lock master total etag LastChangedAt
+   authorization master( global )
+   {
+     field ( readonly ) 
+     OrderUUID,
+     CreatedAt,
+     CreatedBy,
+     LastChangedAt,
+     LastChangedBy,
+     LocalLastChangedAt,
+     PurchaseRequisition,
+     PrCreationDate,
+     DeliveryDate;      
 
-      field ( numbering : managed )
-      OrderUUID;
+     field ( numbering : managed )
+     OrderUUID;
 
-      create;
-      update(features: instance) ;
-      delete;
+     create;
+     update(features: instance) ;
+     delete;
 
-      draft action(features: instance) Edit;
-      draft action Activate;
-      draft action Discard; 
-      draft action Resume;
-      draft determine action Prepare { validation checkOrderedQuantity;  validation checkDeliveryDate;}
-        determination setInitialOrderValues on modify { create; }
-        determination calculateTotalPrice on modify { create; field Price; }
-        validation checkOrderedQuantity on save { create; field OrderQuantity; }
-        validation checkDeliveryDate on save { create; field DeliveryDate; }
+     draft action(features: instance) Edit;
+     draft action Activate;
+     draft action Discard; 
+     draft action Resume;
+     draft determine action Prepare { validation checkOrderedQuantity;  validation checkDeliveryDate;}
+       determination setInitialOrderValues on modify { create; }
+       determination calculateTotalPrice on modify { create; field Price; }
+       validation checkOrderedQuantity on save { create; field OrderQuantity; }
+       validation checkDeliveryDate on save { create; field DeliveryDate; }
 
-      mapping for ZASHOPCART_### 
-      {
-        OrderUUID = order_uuid;
-        OrderID = order_id;
-        OrderedItem = ordered_item;
-        Price = price;
-        TotalPrice = total_price;
-        Currency = currency;
-        OrderQuantity = order_quantity;
-        DeliveryDate = delivery_date;
-        OverallStatus = overall_status;
-        Notes = notes;
-        CreatedBy = created_by;
-        CreatedAt = created_at;
-        LastChangedBy = last_changed_by;
-        LastChangedAt = last_changed_at;
-        LocalLastChangedAt = local_last_changed_at;
-        PurchaseRequisition = purchase_requisition;
-        PrCreationDate = pr_creation_date;
-      }
-    }
-    ```
-    **Hint:** Please replace **`###`** with your ID.
+     mapping for ZASHOPCART_### 
+     {
+       OrderUUID = order_uuid;
+       OrderID = order_id;
+       OrderedItem = ordered_item;
+       Price = price;
+       TotalPrice = total_price;
+       Currency = currency;
+       OrderQuantity = order_quantity;
+       DeliveryDate = delivery_date;
+       OverallStatus = overall_status;
+       Notes = notes;
+       CreatedBy = created_by;
+       CreatedAt = created_at;
+       LastChangedBy = last_changed_by;
+       LastChangedAt = last_changed_at;
+       LocalLastChangedAt = local_last_changed_at;
+       PurchaseRequisition = purchase_requisition;
+       PrCreationDate = pr_creation_date;
+     }
+   }
+   ```
+   **Hint:** Please replace **`###`** with your ID.
     
    4. Save and activate. 
 
@@ -151,50 +151,50 @@ This data definition is needed to create a value help for products.
 
  4. In your data definition **`ZI_Products_###`** replace your code with following:
 
-    ```ABAP
-    @AbapCatalog.viewEnhancementCategory: [#NONE]
-    @AccessControl.authorizationCheck: #NOT_REQUIRED
-    @EndUserText.label: 'Value Help for I_PRODUCT'
-    @Metadata.ignorePropagatedAnnotations: true
-    @ObjectModel.usageType:{
-      serviceQuality: #X,
-      sizeCategory: #S,
-      dataClass: #MIXED
-    }
-    define view entity ZI_PRODUCTS_###
-      as select from I_Product
-    {
-      key Product                                                 as Product,
-          _Text[1: Language=$session.system_language].ProductName as ProductText,
-          @Semantics.amount.currencyCode: 'Currency'
-          case
-            when Product = 'D001' then cast ( 1000.00 as abap.dec(16,2) ) 
-            when Product = 'D002' then cast ( 499.00 as abap.dec(16,2) ) 
-            when Product = 'D003' then cast ( 799.00 as abap.dec(16,2) ) 
-            when Product = 'D004' then cast ( 249.00 as abap.dec(16,2) )
-            when Product = 'D005' then cast ( 1500.00 as abap.dec(16,2) ) 
-            when Product = 'D006' then cast ( 30.00 as abap.dec(16,2) ) 
-            else cast ( 100000.00 as abap.dec(16,2) ) 
-          end                                                     as Price,
-          
-          @UI.hidden: true
-          cast ( 'EUR' as abap.cuky( 5 ) )                        as Currency,
+   ```ABAP
+   @AbapCatalog.viewEnhancementCategory: [#NONE]
+   @AccessControl.authorizationCheck: #NOT_REQUIRED
+   @EndUserText.label: 'Value Help for I_PRODUCT'
+   @Metadata.ignorePropagatedAnnotations: true
+   @ObjectModel.usageType:{
+     serviceQuality: #X,
+     sizeCategory: #S,
+     dataClass: #MIXED
+   }
+   define view entity ZI_PRODUCTS_###
+     as select from I_Product
+   {
+     key Product                                                 as Product,
+         _Text[1: Language=$session.system_language].ProductName as ProductText,
+         @Semantics.amount.currencyCode: 'Currency'
+         case
+           when Product = 'D001' then cast ( 1000.00 as abap.dec(16,2) ) 
+           when Product = 'D002' then cast ( 499.00 as abap.dec(16,2) ) 
+           when Product = 'D003' then cast ( 799.00 as abap.dec(16,2) ) 
+           when Product = 'D004' then cast ( 249.00 as abap.dec(16,2) )
+           when Product = 'D005' then cast ( 1500.00 as abap.dec(16,2) ) 
+           when Product = 'D006' then cast ( 30.00 as abap.dec(16,2) ) 
+           else cast ( 100000.00 as abap.dec(16,2) ) 
+         end                                                     as Price,
+         
+         @UI.hidden: true
+         cast ( 'EUR' as abap.cuky( 5 ) )                        as Currency,
 
-          @UI.hidden: true
-          ProductGroup                                            as ProductGroup,
+         @UI.hidden: true
+         ProductGroup                                            as ProductGroup,
 
-          @UI.hidden: true
-          BaseUnit                                                as BaseUnit
+         @UI.hidden: true
+         BaseUnit                                                as BaseUnit
 
-    }
-    where
-        Product = 'D001'
-      or Product = 'D002'
-      or Product = 'D003'
-      or Product = 'D004'
-      or Product = 'D005'
-      or Product = 'D006'
-    ```
+   }
+   where
+       Product = 'D001'
+     or Product = 'D002'
+     or Product = 'D003'
+     or Product = 'D004'
+     or Product = 'D005'
+     or Product = 'D006'
+   ```
 
  5. Save and activate.
 

--- a/tutorials/abap-s4hanacloud-purchasereq-integrate-api/abap-s4hanacloud-purchasereq-integrate-api.md
+++ b/tutorials/abap-s4hanacloud-purchasereq-integrate-api/abap-s4hanacloud-purchasereq-integrate-api.md
@@ -45,83 +45,83 @@ In this tutorial, wherever `###` appears, use a number (e.g. 000).
 
   1. Add the following action statement for `createPurchaseRequisitionItem ` to your behavior definition **`ZR_SHOPCARTTP_###`**.
 
-    ```ABAP
-    validation checkPurchaseRequisition on save { field OverallStatus; }
-    action ( features : instance ) createPurchaseRequisitionItem result [1] $self;
-    ```
+   ```ABAP
+   validation checkPurchaseRequisition on save { field OverallStatus; }
+   action ( features : instance ) createPurchaseRequisitionItem result [1] $self;
+   ```
    
-     ![projection](bdef5.png)
+   ![projection](bdef5.png)
 
-     **Hint:** Please replace **`###`** with your ID. 
+   **Hint:** Please replace **`###`** with your ID. 
 
   2. Check your behavior definition:
 
-    ```ABAP
-    managed implementation in class ZBP_SHOPCARTTP_### unique;
-    strict ( 2 );
-    with draft;
+   ```ABAP
+   managed implementation in class ZBP_SHOPCARTTP_### unique;
+   strict ( 2 );
+   with draft;
 
-    define behavior for ZR_SHOPCARTTP_### alias ShoppingCart
-    persistent table zashopcart_###
-    draft table ZDSHOPCART_###
-    etag master LocalLastChangedAt
-    lock master total etag LastChangedAt
-    authorization master( global )
+   define behavior for ZR_SHOPCARTTP_### alias ShoppingCart
+   persistent table zashopcart_###
+   draft table ZDSHOPCART_###
+   etag master LocalLastChangedAt
+   lock master total etag LastChangedAt
+   authorization master( global )
 
-    {
-      field ( readonly )
-      OrderUUID,
-      CreatedAt,
-      CreatedBy,
-      LastChangedAt,
-      LastChangedBy,
-      LocalLastChangedAt,
-      PurchaseRequisition,
-      PrCreationDate,
-      DeliveryDate;
+   {
+     field ( readonly )
+     OrderUUID,
+     CreatedAt,
+     CreatedBy,
+     LastChangedAt,
+     LastChangedBy,
+     LocalLastChangedAt,
+     PurchaseRequisition,
+     PrCreationDate,
+     DeliveryDate;
 
-      field ( numbering : managed )
-      OrderUUID;
+     field ( numbering : managed )
+     OrderUUID;
 
-      create;
-      update(features: instance) ;
-      delete;
+     create;
+     update(features: instance) ;
+     delete;
 
-      draft action(features: instance) Edit;
-      draft action Activate;
-      draft action Discard;
-      draft action Resume;
-      draft determine action Prepare { validation checkOrderedQuantity;  validation checkDeliveryDate;}
-        determination setInitialOrderValues on modify { create; }
-        determination calculateTotalPrice on modify { create; field Price; }
-      validation checkOrderedQuantity on save { create; field OrderQuantity; }
-      validation checkDeliveryDate on save { create; field DeliveryDate; }
+     draft action(features: instance) Edit;
+     draft action Activate;
+     draft action Discard;
+     draft action Resume;
+     draft determine action Prepare { validation checkOrderedQuantity;  validation checkDeliveryDate;}
+       determination setInitialOrderValues on modify { create; }
+       determination calculateTotalPrice on modify { create; field Price; }
+     validation checkOrderedQuantity on save { create; field OrderQuantity; }
+     validation checkDeliveryDate on save { create; field DeliveryDate; }
 
-      validation checkPurchaseRequisition on save { field OverallStatus; }
-      action ( features : instance ) createPurchaseRequisitionItem result [1] $self;
+     validation checkPurchaseRequisition on save { field OverallStatus; }
+     action ( features : instance ) createPurchaseRequisitionItem result [1] $self;
 
-      mapping for ZASHOPCART_###
-      {
-        OrderUUID = order_uuid;
-        OrderID = order_id;
-        OrderedItem = ordered_item;
-        Price = price;
-        TotalPrice = total_price;
-        Currency = currency;
-        OrderQuantity = order_quantity;
-        DeliveryDate = delivery_date;
-        OverallStatus = overall_status;
-        Notes = notes;
-        CreatedBy = created_by;
-        CreatedAt = created_at;
-        LastChangedBy = last_changed_by;
-        LastChangedAt = last_changed_at;
-        LocalLastChangedAt = local_last_changed_at;
-        PurchaseRequisition = purchase_requisition;
-        PrCreationDate = pr_creation_date;
-      }
-    }
-    ```
+     mapping for ZASHOPCART_###
+     {
+       OrderUUID = order_uuid;
+       OrderID = order_id;
+       OrderedItem = ordered_item;
+       Price = price;
+       TotalPrice = total_price;
+       Currency = currency;
+       OrderQuantity = order_quantity;
+       DeliveryDate = delivery_date;
+       OverallStatus = overall_status;
+       Notes = notes;
+       CreatedBy = created_by;
+       CreatedAt = created_at;
+       LastChangedBy = last_changed_by;
+       LastChangedAt = last_changed_at;
+       LocalLastChangedAt = local_last_changed_at;
+       PurchaseRequisition = purchase_requisition;
+       PrCreationDate = pr_creation_date;
+     }
+   }
+   ```
 
    3. Save and activate. 
 
@@ -130,34 +130,34 @@ In this tutorial, wherever `###` appears, use a number (e.g. 000).
 
   1. Open your behavior definition **`ZC_SHOPCARTTP_###`** to enhance it. Add action `createPurchaseRequisitionItem` to your behavior definition.
 
-    ```ABAP
-    use action createPurchaseRequisitionItem;
-    ```
+   ```ABAP
+   use action createPurchaseRequisitionItem;
+   ```
     
-    ![projection](actionnew.png)
+   ![projection](actionnew.png)
 
   2. Check your behavior definition:
 
-    ```ABAP
-    projection;
-    strict ( 2 );
-    use draft;
+   ```ABAP
+   projection;
+   strict ( 2 );
+   use draft;
 
-    define behavior for ZC_SHOPCARTTP_### alias ShoppingCart
-    use etag
-    {
-      use create;
-      use update;
-      use delete;
+   define behavior for ZC_SHOPCARTTP_### alias ShoppingCart
+   use etag
+   {
+     use create;
+     use update;
+     use delete;
 
-      use action Edit;
-      use action Activate;
-      use action Discard;
-      use action Resume;
-      use action Prepare;
-      use action createPurchaseRequisitionItem;
-    }
-    ```
+     use action Edit;
+     use action Activate;
+     use action Discard;
+     use action Resume;
+     use action Prepare;
+     use action createPurchaseRequisitionItem;
+   }
+   ```
 
    3. Save and activate.
 
@@ -166,202 +166,202 @@ In this tutorial, wherever `###` appears, use a number (e.g. 000).
 
   1. Open your metadata extension **`ZC_SHOPCARTTP_###`** to enhance it. Add following annotation to `PurchaseRequisition`.
 
-    ```ABAP
-      @UI.lineItem: [ {
-      position: 70 ,
-      label: 'Purchase requisition number',
-      importance: #HIGH
-    },
+   ```ABAP
+     @UI.lineItem: [ {
+     position: 70 ,
+     label: 'Purchase requisition number',
+     importance: #HIGH
+   },
 
-    { type: #FOR_ACTION, dataAction: 'createPurchaseRequisitionItem', label: 'Create Purchase Requisition' } ]
-    @UI.identification: [ { position: 70, label: 'Purchase Requisition Number' } , { type: #FOR_ACTION, dataAction: 'createPurchaseRequisitionItem', label: 'Create Purchase Requisition' } ]
-    PurchaseRequisition;
-    ```
+   { type: #FOR_ACTION, dataAction: 'createPurchaseRequisitionItem', label: 'Create Purchase Requisition' } ]
+   @UI.identification: [ { position: 70, label: 'Purchase Requisition Number' } , { type: #FOR_ACTION, dataAction: 'createPurchaseRequisitionItem', label: 'Create Purchase Requisition' } ]
+   PurchaseRequisition;
+   ```
 
-    ![projection](metadata.png)
+   ![projection](metadata.png)
 
   2. Check your metadata extension:
 
-    ```ABAP
-    @Metadata.layer: #CORE
-    @UI: {
-      headerInfo: {
-        typeName: 'ShoppingCart', 
-        typeNamePlural: 'ShoppingCarts'
-      , title: {
-          type: #STANDARD,
-          label: 'ShoppingCart',
-          value: 'orderid'
-        }
-      },
-      presentationVariant: [ {
-        sortOrder: [ {
-          by: 'orderid',
-          direction: #DESC
-        } ],
-        visualizations: [ {
-          type: #AS_LINEITEM
-        } ]
-      } ]
-    }
-    annotate view ZC_SHOPCARTTP_### with
-    {
-      @UI.facet: [ {
-        id: 'idIdentification', 
-        type: #IDENTIFICATION_REFERENCE, 
-        label: 'ShoppingCart', 
-        position: 10 
-      } ]
-      @UI.hidden: true
-      orderuuid;
-      
-      @UI.lineItem: [ {
-        position: 20 ,
-        importance: #HIGH,
-        label: 'OrderID'
-      } ]
-      @UI.identification: [ {
-        position: 20 ,
-        label: 'OrderID'
-      } ]
-      @UI.selectionField: [ {
-        position: 20
-      } ]
-      orderid;
-      @Consumption.valueHelpDefinition: [{ entity: 
-                    {name: 'ZI_PRODUCTS_###' , element: 'Item' },
-                    additionalBinding: [{ localElement: 'price', element: 'Price', usage: #RESULT }
-                                        ,
-                                        { localElement: 'currency', element: 'Currency', usage: #RESULT }
-                                        ]
-                    }]
-      
-      @UI.lineItem: [ {
-        position: 30 ,
-        importance: #HIGH,
-        label: 'Ordered Item'
-      } ]
-      @UI.identification: [ {
-        position: 30 ,
-        label: 'Ordered Item'
-      } ]
-      @UI.selectionField: [ {
-        position: 30
-      } ]
-      ordereditem;
-      
-      @UI.lineItem: [ {
-        position: 40 ,
-        importance: #HIGH,
-        label: 'Price'
-      } ]
-      @UI.identification: [ {
-        position: 40 ,
-        label: 'Price'
-      } ]
-      @UI.selectionField: [ {
-        position: 40
-      } ]
-      price;
-      
-      @UI.lineItem: [ {
-        position: 45 ,
-        importance: #HIGH,
-        label: 'Total Price'
-      } ]
-      @UI.identification: [ {
-        position: 45 ,
-        label: 'Total Price'
-      } ]
-      @UI.selectionField: [ {
-        position: 50
-      } ]
-      totalprice;
-      @Consumption.valueHelpDefinition: [ { entity: { name: 'I_Currency', element: 'Currency' } } ]
-      @UI.lineItem: [ {
-        position: 50 ,
-        importance: #HIGH,
-        label: 'currency'
-      } ]
-      @UI.identification: [ {
-        position: 50 ,
-        label: 'Currency'
-      } ]
-      @UI.selectionField: [ {
-        position: 60
-      } ]
-      currency;
-      
-      @UI.lineItem: [ {
-        position: 55 ,
-        importance: #HIGH,
-        label: 'Ordered Quantity'
-      } ]
-      @UI.identification: [ {
-        position: 55 ,
-        label: 'Ordered Quantity'
-      } ]
-      @UI.selectionField: [ {
-        position: 65
-      } ]
-      orderquantity;
-      
-      @UI.lineItem: [ {
-        position: 60 ,
-        importance: #HIGH,
-        label: 'Delivery Date'
-      } ]
-      @UI.identification: [ {
-        position: 60 ,
-        label: 'Delivery Date'
-      } ]
-      deliverydate;
-      @UI.lineItem: [ {
-        position: 65 ,
-        importance: #HIGH,
-        label: 'Overall Status'
-      } ]
-      @UI.identification: [ {
-        position: 65 ,
-        label: 'Overall Status'
-      } ]
-      overallstatus;
-    @UI.lineItem: [ {
-        position: 70 ,
-        importance: #HIGH,
-        label: 'Notes'
-      } ]
-      @UI.identification: [ {
-        position: 70 ,
-        label: 'Notes'
-      } ]
-      notes;
-      
-      @UI.hidden: true
-      locallastchangedat;
-      
-      @UI.lineItem: [ {
-        position: 70 ,
-        label: 'Purchase requisition number',
-        importance: #HIGH
-      },
+   ```ABAP
+   @Metadata.layer: #CORE
+   @UI: {
+     headerInfo: {
+       typeName: 'ShoppingCart', 
+       typeNamePlural: 'ShoppingCarts'
+     , title: {
+         type: #STANDARD,
+         label: 'ShoppingCart',
+         value: 'orderid'
+       }
+     },
+     presentationVariant: [ {
+       sortOrder: [ {
+         by: 'orderid',
+         direction: #DESC
+       } ],
+       visualizations: [ {
+         type: #AS_LINEITEM
+       } ]
+     } ]
+   }
+   annotate view ZC_SHOPCARTTP_### with
+   {
+     @UI.facet: [ {
+       id: 'idIdentification', 
+       type: #IDENTIFICATION_REFERENCE, 
+       label: 'ShoppingCart', 
+       position: 10 
+     } ]
+     @UI.hidden: true
+     orderuuid;
+     
+     @UI.lineItem: [ {
+       position: 20 ,
+       importance: #HIGH,
+       label: 'OrderID'
+     } ]
+     @UI.identification: [ {
+       position: 20 ,
+       label: 'OrderID'
+     } ]
+     @UI.selectionField: [ {
+       position: 20
+     } ]
+     orderid;
+     @Consumption.valueHelpDefinition: [{ entity: 
+                   {name: 'ZI_PRODUCTS_###' , element: 'Item' },
+                   additionalBinding: [{ localElement: 'price', element: 'Price', usage: #RESULT }
+                                       ,
+                                       { localElement: 'currency', element: 'Currency', usage: #RESULT }
+                                       ]
+                   }]
+     
+     @UI.lineItem: [ {
+       position: 30 ,
+       importance: #HIGH,
+       label: 'Ordered Item'
+     } ]
+     @UI.identification: [ {
+       position: 30 ,
+       label: 'Ordered Item'
+     } ]
+     @UI.selectionField: [ {
+       position: 30
+     } ]
+     ordereditem;
+     
+     @UI.lineItem: [ {
+       position: 40 ,
+       importance: #HIGH,
+       label: 'Price'
+     } ]
+     @UI.identification: [ {
+       position: 40 ,
+       label: 'Price'
+     } ]
+     @UI.selectionField: [ {
+       position: 40
+     } ]
+     price;
+     
+     @UI.lineItem: [ {
+       position: 45 ,
+       importance: #HIGH,
+       label: 'Total Price'
+     } ]
+     @UI.identification: [ {
+       position: 45 ,
+       label: 'Total Price'
+     } ]
+     @UI.selectionField: [ {
+       position: 50
+     } ]
+     totalprice;
+     @Consumption.valueHelpDefinition: [ { entity: { name: 'I_Currency', element: 'Currency' } } ]
+     @UI.lineItem: [ {
+       position: 50 ,
+       importance: #HIGH,
+       label: 'currency'
+     } ]
+     @UI.identification: [ {
+       position: 50 ,
+       label: 'Currency'
+     } ]
+     @UI.selectionField: [ {
+       position: 60
+     } ]
+     currency;
+     
+     @UI.lineItem: [ {
+       position: 55 ,
+       importance: #HIGH,
+       label: 'Ordered Quantity'
+     } ]
+     @UI.identification: [ {
+       position: 55 ,
+       label: 'Ordered Quantity'
+     } ]
+     @UI.selectionField: [ {
+       position: 65
+     } ]
+     orderquantity;
+     
+     @UI.lineItem: [ {
+       position: 60 ,
+       importance: #HIGH,
+       label: 'Delivery Date'
+     } ]
+     @UI.identification: [ {
+       position: 60 ,
+       label: 'Delivery Date'
+     } ]
+     deliverydate;
+     @UI.lineItem: [ {
+       position: 65 ,
+       importance: #HIGH,
+       label: 'Overall Status'
+     } ]
+     @UI.identification: [ {
+       position: 65 ,
+       label: 'Overall Status'
+     } ]
+     overallstatus;
+   @UI.lineItem: [ {
+       position: 70 ,
+       importance: #HIGH,
+       label: 'Notes'
+     } ]
+     @UI.identification: [ {
+       position: 70 ,
+       label: 'Notes'
+     } ]
+     notes;
+     
+     @UI.hidden: true
+     locallastchangedat;
+     
+     @UI.lineItem: [ {
+       position: 70 ,
+       label: 'Purchase requisition number',
+       importance: #HIGH
+     },
 
-      { type: #FOR_ACTION, dataAction: 'createPurchaseRequisitionItem', label: 'Create Purchase Requisition Item' } ]
-      @UI.identification: [ { position: 70, label: 'Purchase Requisition Number' } , { type: #FOR_ACTION, dataAction: 'createPurchaseRequisitionItem', label: 'Create Purchase Requisition Item' } ]
-      purchaserequisition;
-      
-      @UI.lineItem: [ {
-        position: 75 ,
-        importance: #HIGH,
-        label: 'PR Creation Date'
-      } ]
-      @UI.identification: [ {
-        position: 75 ,
-        label: 'PR Creation Date'
-      } ]
-      prcreationdate;
-    }
-    ```
+     { type: #FOR_ACTION, dataAction: 'createPurchaseRequisitionItem', label: 'Create Purchase Requisition Item' } ]
+     @UI.identification: [ { position: 70, label: 'Purchase Requisition Number' } , { type: #FOR_ACTION, dataAction: 'createPurchaseRequisitionItem', label: 'Create Purchase Requisition Item' } ]
+     purchaserequisition;
+     
+     @UI.lineItem: [ {
+       position: 75 ,
+       importance: #HIGH,
+       label: 'PR Creation Date'
+     } ]
+     @UI.identification: [ {
+       position: 75 ,
+       label: 'PR Creation Date'
+     } ]
+     prcreationdate;
+   }
+   ```
 
    3. Save and activate.
  
@@ -371,119 +371,119 @@ In our scenario, we want to integrate the released purchase requisition API duri
 
   1. Open the behavior definition `ZR_SHOPCARTTP_###`, delete the following line:
   
-    ```ABAP
-    persistent table zashopcart_### 
-    ```
+   ```ABAP
+   persistent table zashopcart_### 
+   ```
   
   2. In your behavior definition **`ZR_SHOPCARTTP_###`** add the `with unmanaged save` statement.
 
-    ```ABAP
-    with unmanaged save
-    ```
-    So that it looks as follows:
+   ```ABAP
+   with unmanaged save
+   ```
+   So that it looks as follows:
 
-    ```ABAP
-    managed implementation in class ZBP_SHOPCARTTP_### unique;
-    strict ( 2 );
-    with draft;
+   ```ABAP
+   managed implementation in class ZBP_SHOPCARTTP_### unique;
+   strict ( 2 );
+   with draft;
 
-    define behavior for ZR_SHOPCARTTP_### alias ShoppingCart
-    draft table ZDSHOPCART_###
-    etag master LocalLastChangedAt
-    lock master total etag LastChangedAt
-    authorization master( global )
-    with unmanaged save
-    {
-      field ( readonly )
-      OrderUUID,
-      CreatedAt,
-      CreatedBy,
-      LastChangedAt,
-      LastChangedBy,
-      LocalLastChangedAt,
-      PurchaseRequisition,
-      PrCreationDate,
-      DeliveryDate;
+   define behavior for ZR_SHOPCARTTP_### alias ShoppingCart
+   draft table ZDSHOPCART_###
+   etag master LocalLastChangedAt
+   lock master total etag LastChangedAt
+   authorization master( global )
+   with unmanaged save
+   {
+     field ( readonly )
+     OrderUUID,
+     CreatedAt,
+     CreatedBy,
+     LastChangedAt,
+     LastChangedBy,
+     LocalLastChangedAt,
+     PurchaseRequisition,
+     PrCreationDate,
+     DeliveryDate;
 
-      field ( numbering : managed )
-      OrderUUID;
+     field ( numbering : managed )
+     OrderUUID;
 
-      create;
-      update(features: instance) ;
-      delete;
+     create;
+     update(features: instance) ;
+     delete;
 
-      draft action(features: instance) Edit;
-      draft action Activate;
-      draft action Discard;
-      draft action Resume;
-      draft determine action Prepare { validation checkOrderedQuantity;  validation checkDeliveryDate;}
-        determination setInitialOrderValues on modify { create; }
-        determination calculateTotalPrice on modify { create; field Price; }
-      validation checkOrderedQuantity on save { create; field OrderQuantity; }
-      validation checkDeliveryDate on save { create; field DeliveryDate; }
+     draft action(features: instance) Edit;
+     draft action Activate;
+     draft action Discard;
+     draft action Resume;
+     draft determine action Prepare { validation checkOrderedQuantity;  validation checkDeliveryDate;}
+       determination setInitialOrderValues on modify { create; }
+       determination calculateTotalPrice on modify { create; field Price; }
+     validation checkOrderedQuantity on save { create; field OrderQuantity; }
+     validation checkDeliveryDate on save { create; field DeliveryDate; }
 
-      validation checkPurchaseRequisition on save { field OverallStatus; }
-      action ( features : instance ) createPurchaseRequisitionItem result [1] $self;
+     validation checkPurchaseRequisition on save { field OverallStatus; }
+     action ( features : instance ) createPurchaseRequisitionItem result [1] $self;
 
-      mapping for ZASHOPCART_###
-      {
-        OrderUUID = order_uuid;
-        OrderID = order_id;
-        OrderedItem = ordered_item;
-        Price = price;
-        TotalPrice = total_price;
-        Currency = currency;
-        OrderQuantity = order_quantity;
-        DeliveryDate = delivery_date;
-        OverallStatus = overall_status;
-        Notes = notes;
-        CreatedBy = created_by;
-        CreatedAt = created_at;
-        LastChangedBy = last_changed_by;
-        LastChangedAt = last_changed_at;
-        LocalLastChangedAt = local_last_changed_at;
-        PurchaseRequisition = purchase_requisition;
-        PrCreationDate = pr_creation_date;
-      }
-    }
-    ```
+     mapping for ZASHOPCART_###
+     {
+       OrderUUID = order_uuid;
+       OrderID = order_id;
+       OrderedItem = ordered_item;
+       Price = price;
+       TotalPrice = total_price;
+       Currency = currency;
+       OrderQuantity = order_quantity;
+       DeliveryDate = delivery_date;
+       OverallStatus = overall_status;
+       Notes = notes;
+       CreatedBy = created_by;
+       CreatedAt = created_at;
+       LastChangedBy = last_changed_by;
+       LastChangedAt = last_changed_at;
+       LocalLastChangedAt = local_last_changed_at;
+       PurchaseRequisition = purchase_requisition;
+       PrCreationDate = pr_creation_date;
+     }
+   }
+   ```
 
   3. Save and activate it. Position the cursor on the with unmanaged save statement and use the shortcut `ctrl + 1` to load the quick assist proposals, then double-click on Add required method `save_modified` in new local saver class to automatically create an empty implementation for the method. Implement it as follows:
 
-    ```ABAP
-    METHOD save_modified.
-      DATA : lt_shopping_cart_as        TYPE STANDARD TABLE OF zashopcart_###.
-      IF create-shoppingcart IS NOT INITIAL.
-        lt_shopping_cart_as = CORRESPONDING #( create-shoppingcart MAPPING FROM ENTITY ).
-        INSERT zashopcart_### FROM TABLE @lt_shopping_cart_as.
-      ENDIF.
-      IF update IS NOT INITIAL.
-        CLEAR lt_shopping_cart_as.
-        lt_shopping_cart_as = CORRESPONDING #( update-shoppingcart MAPPING FROM ENTITY ).
-        LOOP AT update-shoppingcart  INTO DATA(shoppingcart) WHERE OrderUUID IS NOT INITIAL.
-          MODIFY zashopcart_### FROM TABLE @lt_shopping_cart_as.
-        ENDLOOP.
-      ENDIF.
+   ```ABAP
+   METHOD save_modified.
+     DATA : lt_shopping_cart_as        TYPE STANDARD TABLE OF zashopcart_###.
+     IF create-shoppingcart IS NOT INITIAL.
+       lt_shopping_cart_as = CORRESPONDING #( create-shoppingcart MAPPING FROM ENTITY ).
+       INSERT zashopcart_### FROM TABLE @lt_shopping_cart_as.
+     ENDIF.
+     IF update IS NOT INITIAL.
+       CLEAR lt_shopping_cart_as.
+       lt_shopping_cart_as = CORRESPONDING #( update-shoppingcart MAPPING FROM ENTITY ).
+       LOOP AT update-shoppingcart  INTO DATA(shoppingcart) WHERE OrderUUID IS NOT INITIAL.
+         MODIFY zashopcart_### FROM TABLE @lt_shopping_cart_as.
+       ENDLOOP.
+     ENDIF.
 
-      IF update IS NOT INITIAL.
-        DATA(creation_date) = cl_abap_context_info=>get_system_date(  ).
+     IF update IS NOT INITIAL.
+       DATA(creation_date) = cl_abap_context_info=>get_system_date(  ).
 
-        LOOP AT update-shoppingcart INTO DATA(OnlineOrder1) WHERE %control-OverallStatus = if_abap_behv=>mk-on .
-          LOOP AT zbp_shopcarttp_###=>purchase_requisition_details INTO DATA(purchase_reqn_via_eml) WHERE  pid IS NOT INITIAL AND order_uuid = onlineorder1-OrderUUID.
-            CONVERT KEY OF i_purchaserequisitiontp FROM purchase_reqn_via_eml-pid TO DATA(ls_pr_key1).
-            UPDATE zashopcart_### SET purchase_requisition = @ls_pr_key1-PurchaseRequisition,
-                                          pr_creation_date = @creation_date
-                                          WHERE order_uuid = @purchase_reqn_via_eml-Order_UUID.
-          ENDLOOP.
-        ENDLOOP.
-      ENDIF.
+       LOOP AT update-shoppingcart INTO DATA(OnlineOrder1) WHERE %control-OverallStatus = if_abap_behv=>mk-on .
+         LOOP AT zbp_shopcarttp_###=>purchase_requisition_details INTO DATA(purchase_reqn_via_eml) WHERE  pid IS NOT INITIAL AND order_uuid = onlineorder1-OrderUUID.
+           CONVERT KEY OF i_purchaserequisitiontp FROM purchase_reqn_via_eml-pid TO DATA(ls_pr_key1).
+           UPDATE zashopcart_### SET purchase_requisition = @ls_pr_key1-PurchaseRequisition,
+                                         pr_creation_date = @creation_date
+                                         WHERE order_uuid = @purchase_reqn_via_eml-Order_UUID.
+         ENDLOOP.
+       ENDLOOP.
+     ENDIF.
 
-      LOOP AT delete-shoppingcart INTO DATA(shoppingcart_delete) WHERE OrderUUID IS NOT INITIAL.
-        DELETE FROM zashopcart_### WHERE order_uuid = @shoppingcart_delete-OrderUUID.
-        DELETE FROM zdshopcart_### WHERE orderuuid = @shoppingcart_delete-OrderUUID.
-      ENDLOOP.
-    ENDMETHOD.
-    ```
+     LOOP AT delete-shoppingcart INTO DATA(shoppingcart_delete) WHERE OrderUUID IS NOT INITIAL.
+       DELETE FROM zashopcart_### WHERE order_uuid = @shoppingcart_delete-OrderUUID.
+       DELETE FROM zdshopcart_### WHERE orderuuid = @shoppingcart_delete-OrderUUID.
+     ENDLOOP.
+   ENDMETHOD.
+   ```
 
    4. Save, don't activate it yet!
 
@@ -499,413 +499,413 @@ In our scenario, we want to integrate the released purchase requisition API duri
 
   1. In your **Global Class**, replace your code with following:
 
-    ```ABAP
-    class ZBP_SHOPCARTTP_### definition
-      public
-      abstract
-      final
-      for behavior of ZR_SHOPCARTTP_### .
-    public section.
-    TYPES: BEGIN OF ty_pr_details,
-                pid        TYPE abp_behv_pid,
-                cid        TYPE abp_behv_cid,
-                pur_req    TYPE zashopcart_###-purchase_requisition,
-                order_uuid TYPE zashopcart_###-order_uuid,
-              END OF ty_pr_details.
-        CLASS-DATA purchase_requisition_details TYPE TABLE OF ty_pr_details.
-    protected section.
-    private section.
-    ENDCLASS.
+   ```ABAP
+   class ZBP_SHOPCARTTP_### definition
+     public
+     abstract
+     final
+     for behavior of ZR_SHOPCARTTP_### .
+   public section.
+   TYPES: BEGIN OF ty_pr_details,
+               pid        TYPE abp_behv_pid,
+               cid        TYPE abp_behv_cid,
+               pur_req    TYPE zashopcart_###-purchase_requisition,
+               order_uuid TYPE zashopcart_###-order_uuid,
+             END OF ty_pr_details.
+       CLASS-DATA purchase_requisition_details TYPE TABLE OF ty_pr_details.
+   protected section.
+   private section.
+   ENDCLASS.
 
-    ***
+   ***
 
-    CLASS ZBP_SHOPCARTTP_### IMPLEMENTATION.
-    ENDCLASS.
-    ```
+   CLASS ZBP_SHOPCARTTP_### IMPLEMENTATION.
+   ENDCLASS.
+   ```
 
   2. Add the missing constant to your implementation, the `createPurchaseRequisitionItem` action and enhance the `save_modified` method. In your **Local Types**, replace your code with following:
 
-    ```ABAP
-    CLASS lsc_zr_shopcarttp_### DEFINITION INHERITING FROM cl_abap_behavior_saver.
+   ```ABAP
+   CLASS lsc_zr_shopcarttp_### DEFINITION INHERITING FROM cl_abap_behavior_saver.
 
-      PROTECTED SECTION.
+     PROTECTED SECTION.
 
-        METHODS save_modified REDEFINITION.
+       METHODS save_modified REDEFINITION.
 
-    ENDCLASS.
+   ENDCLASS.
 
-    CLASS lsc_zr_shopcarttp_### IMPLEMENTATION.
+   CLASS lsc_zr_shopcarttp_### IMPLEMENTATION.
 
-      METHOD save_modified.
-        DATA : lt_shopping_cart_as        TYPE STANDARD TABLE OF zashopcart_###.
-        IF create-shoppingcart IS NOT INITIAL.
-          lt_shopping_cart_as = CORRESPONDING #( create-shoppingcart MAPPING FROM ENTITY ).
-          INSERT zashopcart_### FROM TABLE @lt_shopping_cart_as.
-        ENDIF.
-        IF update IS NOT INITIAL.
-          CLEAR lt_shopping_cart_as.
-          lt_shopping_cart_as = CORRESPONDING #( update-shoppingcart MAPPING FROM ENTITY ).
-          LOOP AT update-shoppingcart  INTO DATA(shoppingcart) WHERE OrderUUID IS NOT INITIAL.
-            MODIFY zashopcart_### FROM TABLE @lt_shopping_cart_as.
-          ENDLOOP.
-        ENDIF.
+     METHOD save_modified.
+       DATA : lt_shopping_cart_as        TYPE STANDARD TABLE OF zashopcart_###.
+       IF create-shoppingcart IS NOT INITIAL.
+         lt_shopping_cart_as = CORRESPONDING #( create-shoppingcart MAPPING FROM ENTITY ).
+         INSERT zashopcart_### FROM TABLE @lt_shopping_cart_as.
+       ENDIF.
+       IF update IS NOT INITIAL.
+         CLEAR lt_shopping_cart_as.
+         lt_shopping_cart_as = CORRESPONDING #( update-shoppingcart MAPPING FROM ENTITY ).
+         LOOP AT update-shoppingcart  INTO DATA(shoppingcart) WHERE OrderUUID IS NOT INITIAL.
+           MODIFY zashopcart_### FROM TABLE @lt_shopping_cart_as.
+         ENDLOOP.
+       ENDIF.
 
-    *************Add CONVERT KEY statement for Purchase Requisition create in case of EML implementation type**********
+   *************Add CONVERT KEY statement for Purchase Requisition create in case of EML implementation type**********
 
-      IF update IS NOT INITIAL.
-          DATA(creation_date) = cl_abap_context_info=>get_system_date(  ).
+     IF update IS NOT INITIAL.
+         DATA(creation_date) = cl_abap_context_info=>get_system_date(  ).
 
-          LOOP AT update-shoppingcart INTO DATA(OnlineOrder1) WHERE %control-OverallStatus = if_abap_behv=>mk-on .
-            LOOP AT zbp_shopcarttp_###=>purchase_requisition_details INTO DATA(purchase_reqn_via_eml) WHERE  pid IS NOT INITIAL AND order_uuid = onlineorder1-OrderUUID.
-              CONVERT KEY OF i_purchaserequisitiontp FROM purchase_reqn_via_eml-pid TO DATA(ls_pr_key1).
-              UPDATE zashopcart_### SET purchase_requisition = @ls_pr_key1-PurchaseRequisition,
-                                            pr_creation_date = @creation_date
-                                            WHERE order_uuid = @purchase_reqn_via_eml-Order_UUID.
-            ENDLOOP.
-          ENDLOOP.
-        ENDIF.
-    ************END of CONVER KEY EML code snippet******************
+         LOOP AT update-shoppingcart INTO DATA(OnlineOrder1) WHERE %control-OverallStatus = if_abap_behv=>mk-on .
+           LOOP AT zbp_shopcarttp_###=>purchase_requisition_details INTO DATA(purchase_reqn_via_eml) WHERE  pid IS NOT INITIAL AND order_uuid = onlineorder1-OrderUUID.
+             CONVERT KEY OF i_purchaserequisitiontp FROM purchase_reqn_via_eml-pid TO DATA(ls_pr_key1).
+             UPDATE zashopcart_### SET purchase_requisition = @ls_pr_key1-PurchaseRequisition,
+                                           pr_creation_date = @creation_date
+                                           WHERE order_uuid = @purchase_reqn_via_eml-Order_UUID.
+           ENDLOOP.
+         ENDLOOP.
+       ENDIF.
+   ************END of CONVER KEY EML code snippet******************
 
-        LOOP AT delete-shoppingcart INTO DATA(shoppingcart_delete) WHERE OrderUUID IS NOT INITIAL.
-          DELETE FROM zashopcart_### WHERE order_uuid = @shoppingcart_delete-OrderUUID.
-          DELETE FROM zdshopcart_### WHERE orderuuid = @shoppingcart_delete-OrderUUID.
-        ENDLOOP.
-      ENDMETHOD.
+       LOOP AT delete-shoppingcart INTO DATA(shoppingcart_delete) WHERE OrderUUID IS NOT INITIAL.
+         DELETE FROM zashopcart_### WHERE order_uuid = @shoppingcart_delete-OrderUUID.
+         DELETE FROM zdshopcart_### WHERE orderuuid = @shoppingcart_delete-OrderUUID.
+       ENDLOOP.
+     ENDMETHOD.
 
-    ENDCLASS.
+   ENDCLASS.
 
-    CLASS lhc_shopcart DEFINITION INHERITING FROM cl_abap_behavior_handler.
-      PRIVATE SECTION.
-        CONSTANTS:
-          BEGIN OF c_overall_status,
-            new       TYPE string VALUE 'New / Composing',
-            submitted TYPE string VALUE 'Submitted / Approved',
-            cancelled TYPE string VALUE 'Cancelled',
-          END OF c_overall_status.
-        METHODS:
-          get_global_authorizations FOR GLOBAL AUTHORIZATION
-            IMPORTING
-            REQUEST requested_authorizations FOR ShoppingCart
-            RESULT result,
-          get_instance_features FOR INSTANCE FEATURES
-            IMPORTING keys REQUEST requested_features FOR ShoppingCart RESULT result.
+   CLASS lhc_shopcart DEFINITION INHERITING FROM cl_abap_behavior_handler.
+     PRIVATE SECTION.
+       CONSTANTS:
+         BEGIN OF c_overall_status,
+           new       TYPE string VALUE 'New / Composing',
+           submitted TYPE string VALUE 'Submitted / Approved',
+           cancelled TYPE string VALUE 'Cancelled',
+         END OF c_overall_status.
+       METHODS:
+         get_global_authorizations FOR GLOBAL AUTHORIZATION
+           IMPORTING
+           REQUEST requested_authorizations FOR ShoppingCart
+           RESULT result,
+         get_instance_features FOR INSTANCE FEATURES
+           IMPORTING keys REQUEST requested_features FOR ShoppingCart RESULT result.
 
-        METHODS calculateTotalPrice FOR DETERMINE ON MODIFY
-          IMPORTING keys FOR ShoppingCart~calculateTotalPrice.
+       METHODS calculateTotalPrice FOR DETERMINE ON MODIFY
+         IMPORTING keys FOR ShoppingCart~calculateTotalPrice.
 
-        METHODS setInitialOrderValues FOR DETERMINE ON MODIFY
-          IMPORTING keys FOR ShoppingCart~setInitialOrderValues.
+       METHODS setInitialOrderValues FOR DETERMINE ON MODIFY
+         IMPORTING keys FOR ShoppingCart~setInitialOrderValues.
 
-        METHODS checkDeliveryDate FOR VALIDATE ON SAVE
-          IMPORTING keys FOR ShoppingCart~checkDeliveryDate.
+       METHODS checkDeliveryDate FOR VALIDATE ON SAVE
+         IMPORTING keys FOR ShoppingCart~checkDeliveryDate.
 
-        METHODS checkOrderedQuantity FOR VALIDATE ON SAVE
-          IMPORTING keys FOR ShoppingCart~checkOrderedQuantity.
+       METHODS checkOrderedQuantity FOR VALIDATE ON SAVE
+         IMPORTING keys FOR ShoppingCart~checkOrderedQuantity.
 
-        METHODS createPurchaseRequisitionItem FOR MODIFY
-          IMPORTING keys FOR ACTION ShoppingCart~createPurchaseRequisitionItem RESULT result.
+       METHODS createPurchaseRequisitionItem FOR MODIFY
+         IMPORTING keys FOR ACTION ShoppingCart~createPurchaseRequisitionItem RESULT result.
 
-        METHODS checkPurchaseRequisition FOR VALIDATE ON SAVE
-          IMPORTING keys FOR ShoppingCart~checkPurchaseRequisition.
+       METHODS checkPurchaseRequisition FOR VALIDATE ON SAVE
+         IMPORTING keys FOR ShoppingCart~checkPurchaseRequisition.
 
-    ENDCLASS.
+   ENDCLASS.
 
-    CLASS lhc_shopcart IMPLEMENTATION.
+   CLASS lhc_shopcart IMPLEMENTATION.
 
-      METHOD get_global_authorizations.
-      ENDMETHOD.
+     METHOD get_global_authorizations.
+     ENDMETHOD.
 
-      METHOD get_instance_features.
-        " read relevant olineShop instance data
-        READ ENTITIES OF zr_shopcarttp_### IN LOCAL MODE
-          ENTITY ShoppingCart
-            FIELDS ( OverallStatus )
-            WITH CORRESPONDING #( keys )
-          RESULT DATA(OnlineOrders)
-          FAILED failed.
+     METHOD get_instance_features.
+       " read relevant olineShop instance data
+       READ ENTITIES OF zr_shopcarttp_### IN LOCAL MODE
+         ENTITY ShoppingCart
+           FIELDS ( OverallStatus )
+           WITH CORRESPONDING #( keys )
+         RESULT DATA(OnlineOrders)
+         FAILED failed.
 
-        " evaluate condition, set operation state, and set result parameter
-        " update and checkout shall not be allowed as soon as purchase requisition has been created
-        result = VALUE #( FOR OnlineOrder IN OnlineOrders
-                          ( %tky                   = OnlineOrder-%tky
-                            %features-%update
-                              = COND #( WHEN OnlineOrder-OverallStatus = c_overall_status-submitted  THEN if_abap_behv=>fc-o-disabled
-                                        WHEN OnlineOrder-OverallStatus = c_overall_status-cancelled THEN if_abap_behv=>fc-o-disabled
-                                        ELSE if_abap_behv=>fc-o-enabled   )
-                            %action-Edit
-                              = COND #( WHEN OnlineOrder-OverallStatus = c_overall_status-submitted THEN if_abap_behv=>fc-o-disabled
-                                        WHEN OnlineOrder-OverallStatus = c_overall_status-cancelled THEN if_abap_behv=>fc-o-disabled
-                                        ELSE if_abap_behv=>fc-o-enabled   )
-                            %action-createPurchaseRequisitionItem
-                              = COND #( WHEN OnlineOrder-OverallStatus = c_overall_status-submitted OR OnlineOrder-%is_draft = if_abap_behv=>mk-on
-                                        THEN if_abap_behv=>fc-o-disabled
-                                        ELSE if_abap_behv=>fc-o-enabled )
-                            ) ).
-      ENDMETHOD.
+       " evaluate condition, set operation state, and set result parameter
+       " update and checkout shall not be allowed as soon as purchase requisition has been created
+       result = VALUE #( FOR OnlineOrder IN OnlineOrders
+                         ( %tky                   = OnlineOrder-%tky
+                           %features-%update
+                             = COND #( WHEN OnlineOrder-OverallStatus = c_overall_status-submitted  THEN if_abap_behv=>fc-o-disabled
+                                       WHEN OnlineOrder-OverallStatus = c_overall_status-cancelled THEN if_abap_behv=>fc-o-disabled
+                                       ELSE if_abap_behv=>fc-o-enabled   )
+                           %action-Edit
+                             = COND #( WHEN OnlineOrder-OverallStatus = c_overall_status-submitted THEN if_abap_behv=>fc-o-disabled
+                                       WHEN OnlineOrder-OverallStatus = c_overall_status-cancelled THEN if_abap_behv=>fc-o-disabled
+                                       ELSE if_abap_behv=>fc-o-enabled   )
+                           %action-createPurchaseRequisitionItem
+                             = COND #( WHEN OnlineOrder-OverallStatus = c_overall_status-submitted OR OnlineOrder-%is_draft = if_abap_behv=>mk-on
+                                       THEN if_abap_behv=>fc-o-disabled
+                                       ELSE if_abap_behv=>fc-o-enabled )
+                           ) ).
+     ENDMETHOD.
 
-      METHOD calculateTotalPrice.
-        " read transfered instances
-        READ ENTITIES OF zr_shopcarttp_### IN LOCAL MODE
-          ENTITY ShoppingCart
-            FIELDS ( OrderID TotalPrice Price OrderQuantity )
-            WITH CORRESPONDING #( keys )
-          RESULT DATA(OnlineOrders).
+     METHOD calculateTotalPrice.
+       " read transfered instances
+       READ ENTITIES OF zr_shopcarttp_### IN LOCAL MODE
+         ENTITY ShoppingCart
+           FIELDS ( OrderID TotalPrice Price OrderQuantity )
+           WITH CORRESPONDING #( keys )
+         RESULT DATA(OnlineOrders).
 
-        LOOP AT OnlineOrders ASSIGNING FIELD-SYMBOL(<OnlineOrder>).
-          " calculate total value
-          <OnlineOrder>-TotalPrice = <OnlineOrder>-Price * <OnlineOrder>-OrderQuantity.
-        ENDLOOP.
+       LOOP AT OnlineOrders ASSIGNING FIELD-SYMBOL(<OnlineOrder>).
+         " calculate total value
+         <OnlineOrder>-TotalPrice = <OnlineOrder>-Price * <OnlineOrder>-OrderQuantity.
+       ENDLOOP.
 
-        "update instances
-        MODIFY ENTITIES OF zr_shopcarttp_### IN LOCAL MODE
-          ENTITY ShoppingCart
-            UPDATE FIELDS ( TotalPrice )
-            WITH VALUE #( FOR OnlineOrder IN OnlineOrders (
-                              %tky       = OnlineOrder-%tky
-                              TotalPrice = <OnlineOrder>-TotalPrice
-                            ) ).
-      ENDMETHOD.
+       "update instances
+       MODIFY ENTITIES OF zr_shopcarttp_### IN LOCAL MODE
+         ENTITY ShoppingCart
+           UPDATE FIELDS ( TotalPrice )
+           WITH VALUE #( FOR OnlineOrder IN OnlineOrders (
+                             %tky       = OnlineOrder-%tky
+                             TotalPrice = <OnlineOrder>-TotalPrice
+                           ) ).
+     ENDMETHOD.
 
-      METHOD setInitialOrderValues.
-        DATA delivery_date TYPE I_PurchaseReqnItemTP-DeliveryDate.
-        DATA(creation_date) = cl_abap_context_info=>get_system_date(  ).
-        "set delivery date proposal
-        delivery_date = cl_abap_context_info=>get_system_date(  ) + 14.
-        "read transfered instances
-        READ ENTITIES OF ZR_shopcarttp_### IN LOCAL MODE
-          ENTITY ShoppingCart
-            FIELDS ( OrderID OverallStatus  DeliveryDate OrderQuantity  )
-            WITH CORRESPONDING #( keys )
-          RESULT DATA(OnlineOrders).
+     METHOD setInitialOrderValues.
+       DATA delivery_date TYPE I_PurchaseReqnItemTP-DeliveryDate.
+       DATA(creation_date) = cl_abap_context_info=>get_system_date(  ).
+       "set delivery date proposal
+       delivery_date = cl_abap_context_info=>get_system_date(  ) + 14.
+       "read transfered instances
+       READ ENTITIES OF ZR_shopcarttp_### IN LOCAL MODE
+         ENTITY ShoppingCart
+           FIELDS ( OrderID OverallStatus  DeliveryDate OrderQuantity  )
+           WITH CORRESPONDING #( keys )
+         RESULT DATA(OnlineOrders).
 
-        "delete entries with assigned order ID
-        DELETE OnlineOrders WHERE OrderID IS NOT INITIAL.
-        CHECK OnlineOrders IS NOT INITIAL.
+       "delete entries with assigned order ID
+       DELETE OnlineOrders WHERE OrderID IS NOT INITIAL.
+       CHECK OnlineOrders IS NOT INITIAL.
 
-        " **Dummy logic to determine order IDs**
-        " get max order ID from the relevant active and draft table entries
-        SELECT MAX( order_id ) FROM zashopcart_### INTO @DATA(max_order_id). "active table
-        SELECT SINGLE FROM zdshopcart_### FIELDS MAX( orderid ) INTO @DATA(max_orderid_draft). "draft table
-        IF max_orderid_draft > max_order_id.
-          max_order_id = max_orderid_draft.
-        ENDIF.
+       " **Dummy logic to determine order IDs**
+       " get max order ID from the relevant active and draft table entries
+       SELECT MAX( order_id ) FROM zashopcart_### INTO @DATA(max_order_id). "active table
+       SELECT SINGLE FROM zdshopcart_### FIELDS MAX( orderid ) INTO @DATA(max_orderid_draft). "draft table
+       IF max_orderid_draft > max_order_id.
+         max_order_id = max_orderid_draft.
+       ENDIF.
 
-        "set initial values of new instances
-        MODIFY ENTITIES OF zr_shopcarttp_### IN LOCAL MODE
-          ENTITY ShoppingCart
-            UPDATE FIELDS ( OrderID OverallStatus  DeliveryDate   )
-            WITH VALUE #( FOR order IN OnlineOrders INDEX INTO i (
-                              %tky          = order-%tky
-                              OrderID       = max_order_id + i
-                              OverallStatus = c_overall_status-new  "'New / Composing'
-    *                          Price         = COND #( WHEN order-OrderedItem = 'desktop' then 1500
-    *                                                  when order-OrderedItem = 'laptop' then  2### )
+       "set initial values of new instances
+       MODIFY ENTITIES OF zr_shopcarttp_### IN LOCAL MODE
+         ENTITY ShoppingCart
+           UPDATE FIELDS ( OrderID OverallStatus  DeliveryDate   )
+           WITH VALUE #( FOR order IN OnlineOrders INDEX INTO i (
+                             %tky          = order-%tky
+                             OrderID       = max_order_id + i
+                             OverallStatus = c_overall_status-new  "'New / Composing'
+   *                          Price         = COND #( WHEN order-OrderedItem = 'desktop' then 1500
+   *                                                  when order-OrderedItem = 'laptop' then  2### )
 
-                              DeliveryDate  = delivery_date
-                              CreatedAt     = creation_date
-                            ) ).
-      ENDMETHOD.
+                             DeliveryDate  = delivery_date
+                             CreatedAt     = creation_date
+                           ) ).
+     ENDMETHOD.
 
-      METHOD checkDeliveryDate.
-    *   " read transfered instances
-        READ ENTITIES OF zr_shopcarttp_### IN LOCAL MODE
-          ENTITY ShoppingCart
-            FIELDS ( DeliveryDate )
-            WITH CORRESPONDING #( keys )
-          RESULT DATA(OnlineOrders).
+     METHOD checkDeliveryDate.
+   *   " read transfered instances
+       READ ENTITIES OF zr_shopcarttp_### IN LOCAL MODE
+         ENTITY ShoppingCart
+           FIELDS ( DeliveryDate )
+           WITH CORRESPONDING #( keys )
+         RESULT DATA(OnlineOrders).
 
-        DATA(creation_date) = cl_abap_context_info=>get_system_date(  ).
-        "raise msg if 0 > qty <= 10
-        LOOP AT OnlineOrders INTO DATA(online_order).
-          IF online_order-DeliveryDate IS INITIAL OR online_order-DeliveryDate = ' '.
-            APPEND VALUE #( %tky = online_order-%tky ) TO failed-ShoppingCart.
-            APPEND VALUE #( %tky         = online_order-%tky
-                            %state_area   = 'VALIDATE_DELIVERYDATE'
-                            %msg          = new_message_with_text(
-                                    severity = if_abap_behv_message=>severity-error
-                                    text     = 'Delivery Date cannot be initial' )
-                          ) TO reported-ShoppingCart.
+       DATA(creation_date) = cl_abap_context_info=>get_system_date(  ).
+       "raise msg if 0 > qty <= 10
+       LOOP AT OnlineOrders INTO DATA(online_order).
+         IF online_order-DeliveryDate IS INITIAL OR online_order-DeliveryDate = ' '.
+           APPEND VALUE #( %tky = online_order-%tky ) TO failed-ShoppingCart.
+           APPEND VALUE #( %tky         = online_order-%tky
+                           %state_area   = 'VALIDATE_DELIVERYDATE'
+                           %msg          = new_message_with_text(
+                                   severity = if_abap_behv_message=>severity-error
+                                   text     = 'Delivery Date cannot be initial' )
+                         ) TO reported-ShoppingCart.
 
-          ELSEIF  ( ( online_order-DeliveryDate ) - creation_date ) < 14.
-            APPEND VALUE #(  %tky = online_order-%tky ) TO failed-ShoppingCart.
-            APPEND VALUE #(  %tky          = online_order-%tky
-                            %state_area   = 'VALIDATE_DELIVERYDATE'
-                            %msg          = new_message_with_text(
-                                    severity = if_abap_behv_message=>severity-error
-                                    text     = 'Delivery Date should be atleast 14 days after the creation date'  )
+         ELSEIF  ( ( online_order-DeliveryDate ) - creation_date ) < 14.
+           APPEND VALUE #(  %tky = online_order-%tky ) TO failed-ShoppingCart.
+           APPEND VALUE #(  %tky          = online_order-%tky
+                           %state_area   = 'VALIDATE_DELIVERYDATE'
+                           %msg          = new_message_with_text(
+                                   severity = if_abap_behv_message=>severity-error
+                                   text     = 'Delivery Date should be atleast 14 days after the creation date'  )
 
-                            %element-orderquantity  = if_abap_behv=>mk-on
-                          ) TO reported-ShoppingCart.
-          ENDIF.
-        ENDLOOP.
-      ENDMETHOD.
+                           %element-orderquantity  = if_abap_behv=>mk-on
+                         ) TO reported-ShoppingCart.
+         ENDIF.
+       ENDLOOP.
+     ENDMETHOD.
 
-      METHOD checkOrderedQuantity.
-        "read relevant order instance data
-        READ ENTITIES OF zr_shopcarttp_### IN LOCAL MODE
-        ENTITY ShoppingCart
-        FIELDS ( OrderID OrderedItem OrderQuantity )
-        WITH CORRESPONDING #( keys )
-        RESULT DATA(OnlineOrders).
+     METHOD checkOrderedQuantity.
+       "read relevant order instance data
+       READ ENTITIES OF zr_shopcarttp_### IN LOCAL MODE
+       ENTITY ShoppingCart
+       FIELDS ( OrderID OrderedItem OrderQuantity )
+       WITH CORRESPONDING #( keys )
+       RESULT DATA(OnlineOrders).
 
-        "raise msg if 0 > qty <= 10
-        LOOP AT OnlineOrders INTO DATA(OnlineOrder).
-          APPEND VALUE #(  %tky           = OnlineOrder-%tky
-                          %state_area    = 'VALIDATE_QUANTITY'
-                        ) TO reported-ShoppingCart.
+       "raise msg if 0 > qty <= 10
+       LOOP AT OnlineOrders INTO DATA(OnlineOrder).
+         APPEND VALUE #(  %tky           = OnlineOrder-%tky
+                         %state_area    = 'VALIDATE_QUANTITY'
+                       ) TO reported-ShoppingCart.
 
-          IF OnlineOrder-OrderQuantity IS INITIAL OR OnlineOrder-OrderQuantity = ' '.
-            APPEND VALUE #( %tky = OnlineOrder-%tky ) TO failed-ShoppingCart.
-            APPEND VALUE #( %tky          = OnlineOrder-%tky
-                            %state_area   = 'VALIDATE_QUANTITY'
-                            %msg          = new_message_with_text(
-                                    severity = if_abap_behv_message=>severity-error
-                                    text     = 'Quantity cannot be empty' )
-                            %element-orderquantity = if_abap_behv=>mk-on
-                          ) TO reported-ShoppingCart.
+         IF OnlineOrder-OrderQuantity IS INITIAL OR OnlineOrder-OrderQuantity = ' '.
+           APPEND VALUE #( %tky = OnlineOrder-%tky ) TO failed-ShoppingCart.
+           APPEND VALUE #( %tky          = OnlineOrder-%tky
+                           %state_area   = 'VALIDATE_QUANTITY'
+                           %msg          = new_message_with_text(
+                                   severity = if_abap_behv_message=>severity-error
+                                   text     = 'Quantity cannot be empty' )
+                           %element-orderquantity = if_abap_behv=>mk-on
+                         ) TO reported-ShoppingCart.
 
-          ELSEIF OnlineOrder-OrderQuantity > 10.
-            APPEND VALUE #(  %tky = OnlineOrder-%tky ) TO failed-ShoppingCart.
-            APPEND VALUE #(  %tky          = OnlineOrder-%tky
-                            %state_area   = 'VALIDATE_QUANTITY'
-                            %msg          = new_message_with_text(
-                                    severity = if_abap_behv_message=>severity-error
-                                    text     = 'Quantity should be below 10' )
+         ELSEIF OnlineOrder-OrderQuantity > 10.
+           APPEND VALUE #(  %tky = OnlineOrder-%tky ) TO failed-ShoppingCart.
+           APPEND VALUE #(  %tky          = OnlineOrder-%tky
+                           %state_area   = 'VALIDATE_QUANTITY'
+                           %msg          = new_message_with_text(
+                                   severity = if_abap_behv_message=>severity-error
+                                   text     = 'Quantity should be below 10' )
 
-                            %element-orderquantity  = if_abap_behv=>mk-on
-                          ) TO reported-ShoppingCart.
-          ENDIF.
-        ENDLOOP.
-      ENDMETHOD.
+                           %element-orderquantity  = if_abap_behv=>mk-on
+                         ) TO reported-ShoppingCart.
+         ENDIF.
+       ENDLOOP.
+     ENDMETHOD.
 
-      METHOD createpurchaserequisitionitem.
-        READ ENTITIES OF zr_shopcarttp_### IN LOCAL MODE
-        ENTITY ShoppingCart
-          ALL FIELDS WITH
-          CORRESPONDING #( keys )
-        RESULT DATA(OnlineOrders).
-    ***Integrate EML statement for Purchase Requisition create in case of released API implementation scenario ************
-    ***Begin of Code Snippet********
-        DATA: purchase_requisitions      TYPE TABLE FOR CREATE I_PurchaserequisitionTP,
-              purchase_requisition       TYPE STRUCTURE FOR CREATE I_PurchaserequisitionTP,
-              purchase_requisition_items TYPE TABLE FOR CREATE i_purchaserequisitionTP\_PurchaseRequisitionItem,
-              purchase_requisition_item  TYPE STRUCTURE FOR CREATE i_purchaserequisitiontp\\purchaserequisition\_purchaserequisitionitem,
-              delivery_date              TYPE I_PurchaseReqnItemTP-DeliveryDate,
-              n                          TYPE i.
-        LOOP AT onlineorders INTO DATA(onlineorder) WHERE OverallStatus = c_overall_status-new .
-    *   SQL statement to include product and productgroup
-          SELECT SINGLE FROM zi_products_### FIELDS product, productgroup WHERE ProductText = @onlineorder-OrderedItem INTO @DATA(productdata) .
-    *
-    *      delivery_date = cl_abap_context_info=>get_system_date(  ) .
-          delivery_date = cl_abap_context_info=>get_system_date(  ) + 14 .
-          n += 1.
-          "purchase requisition
-          DATA(cid) = onlineorder-OrderID && '_' && n.
-          purchase_requisition = VALUE #(   %cid                      = cid
-                                            purchaserequisitiontype   = 'NB'  ) .
-          APPEND purchase_requisition TO purchase_requisitions.
+     METHOD createpurchaserequisitionitem.
+       READ ENTITIES OF zr_shopcarttp_### IN LOCAL MODE
+       ENTITY ShoppingCart
+         ALL FIELDS WITH
+         CORRESPONDING #( keys )
+       RESULT DATA(OnlineOrders).
+   ***Integrate EML statement for Purchase Requisition create in case of released API implementation scenario ************
+   ***Begin of Code Snippet********
+       DATA: purchase_requisitions      TYPE TABLE FOR CREATE I_PurchaserequisitionTP,
+             purchase_requisition       TYPE STRUCTURE FOR CREATE I_PurchaserequisitionTP,
+             purchase_requisition_items TYPE TABLE FOR CREATE i_purchaserequisitionTP\_PurchaseRequisitionItem,
+             purchase_requisition_item  TYPE STRUCTURE FOR CREATE i_purchaserequisitiontp\\purchaserequisition\_purchaserequisitionitem,
+             delivery_date              TYPE I_PurchaseReqnItemTP-DeliveryDate,
+             n                          TYPE i.
+       LOOP AT onlineorders INTO DATA(onlineorder) WHERE OverallStatus = c_overall_status-new .
+   *   SQL statement to include product and productgroup
+         SELECT SINGLE FROM zi_products_### FIELDS product, productgroup WHERE ProductText = @onlineorder-OrderedItem INTO @DATA(productdata) .
+   *
+   *      delivery_date = cl_abap_context_info=>get_system_date(  ) .
+         delivery_date = cl_abap_context_info=>get_system_date(  ) + 14 .
+         n += 1.
+         "purchase requisition
+         DATA(cid) = onlineorder-OrderID && '_' && n.
+         purchase_requisition = VALUE #(   %cid                      = cid
+                                           purchaserequisitiontype   = 'NB'  ) .
+         APPEND purchase_requisition TO purchase_requisitions.
 
-          "purchase requisition item
-          purchase_requisition_item = VALUE #(
-                                            %cid_ref = cid
-                                            %target  = VALUE #(  (
-                                                          %cid                         = |My%ItemCID_{ n }|
-                                                          plant                        = '1010'  "Plant 01 (DE)
-                                                          accountassignmentcategory    = 'U'  "unknown
-    *                                                       PurchaseRequisitionItemText =  . "retrieved automatically from maintained MaterialInfo
-                                                          requestedquantity            = onlineorder-OrderQuantity
-                                                          purchaserequisitionprice     = onlineorder-Price
-                                                          purreqnitemcurrency          = onlineorder-Currency
-                                                          Material                     = productdata-Product
+         "purchase requisition item
+         purchase_requisition_item = VALUE #(
+                                           %cid_ref = cid
+                                           %target  = VALUE #(  (
+                                                         %cid                         = |My%ItemCID_{ n }|
+                                                         plant                        = '1010'  "Plant 01 (DE)
+                                                         accountassignmentcategory    = 'U'  "unknown
+   *                                                       PurchaseRequisitionItemText =  . "retrieved automatically from maintained MaterialInfo
+                                                         requestedquantity            = onlineorder-OrderQuantity
+                                                         purchaserequisitionprice     = onlineorder-Price
+                                                         purreqnitemcurrency          = onlineorder-Currency
+                                                         Material                     = productdata-Product
 
-                                                          materialgroup               = productdata-Productgroup
-    *                                                        Material                  = 'laptop'
-    *                                                       materialgroup              = 'system'
-                                                          purchasinggroup             = '001'
-    *                                                       purchasingorganization     = '1010'
-                                                          DeliveryDate                = delivery_date   "delivery_date  "yyyy-mm-dd (at least 10 days)
-                                                          CreatedByUser               = OnlineOrder-CreatedBy
-                                                          ) ) ).
-          APPEND purchase_requisition_item TO purchase_requisition_items.
-        ENDLOOP.
-        IF keys IS NOT INITIAL .
-          "purchase requisition
-          MODIFY ENTITIES OF i_purchaserequisitiontp
-            ENTITY purchaserequisition
-              CREATE FIELDS ( purchaserequisitiontype )
-              WITH purchase_requisitions
-            "purchase requisition item
-            CREATE BY \_purchaserequisitionitem
-              FIELDS ( plant
-    *                  purchaserequisitionitemtext
-                      accountassignmentcategory
-                      requestedquantity
-                      baseunit
-                      purchaserequisitionprice
-                      purreqnitemcurrency
-                      Material
-                      materialgroup
-                      purchasinggroup
-                      purchasingorganization
-                      DeliveryDate
+                                                         materialgroup               = productdata-Productgroup
+   *                                                        Material                  = 'laptop'
+   *                                                       materialgroup              = 'system'
+                                                         purchasinggroup             = '001'
+   *                                                       purchasingorganization     = '1010'
+                                                         DeliveryDate                = delivery_date   "delivery_date  "yyyy-mm-dd (at least 10 days)
+                                                         CreatedByUser               = OnlineOrder-CreatedBy
+                                                         ) ) ).
+         APPEND purchase_requisition_item TO purchase_requisition_items.
+       ENDLOOP.
+       IF keys IS NOT INITIAL .
+         "purchase requisition
+         MODIFY ENTITIES OF i_purchaserequisitiontp
+           ENTITY purchaserequisition
+             CREATE FIELDS ( purchaserequisitiontype )
+             WITH purchase_requisitions
+           "purchase requisition item
+           CREATE BY \_purchaserequisitionitem
+             FIELDS ( plant
+   *                  purchaserequisitionitemtext
+                     accountassignmentcategory
+                     requestedquantity
+                     baseunit
+                     purchaserequisitionprice
+                     purreqnitemcurrency
+                     Material
+                     materialgroup
+                     purchasinggroup
+                     purchasingorganization
+                     DeliveryDate
 
-                    )
-            WITH purchase_requisition_items
-          REPORTED DATA(reported_create_pr)
-          MAPPED DATA(mapped_create_pr)
-          FAILED DATA(failed_create_pr).
-          READ ENTITIES OF I_PurchaseRequisitionTP
-          ENTITY PurchaseRequisition
-          ALL FIELDS WITH CORRESPONDING #( mapped_create_pr-purchaserequisition )
-          RESULT DATA(pr_result)
-          FAILED DATA(pr_failed)
-          REPORTED DATA(pr_reported).
-        ENDIF.
+                   )
+           WITH purchase_requisition_items
+         REPORTED DATA(reported_create_pr)
+         MAPPED DATA(mapped_create_pr)
+         FAILED DATA(failed_create_pr).
+         READ ENTITIES OF I_PurchaseRequisitionTP
+         ENTITY PurchaseRequisition
+         ALL FIELDS WITH CORRESPONDING #( mapped_create_pr-purchaserequisition )
+         RESULT DATA(pr_result)
+         FAILED DATA(pr_failed)
+         REPORTED DATA(pr_reported).
+       ENDIF.
 
-        IF mapped_create_pr IS NOT INITIAL.
-          LOOP AT onlineorders INTO DATA(onlineorder1) WHERE OverallStatus = c_overall_status-new .
-            LOOP AT mapped_create_pr-purchaserequisition INTO DATA(purchaserequisition_details)   .
-              IF onlineorder1-OrderID = substring_before( val = purchaserequisition_details-%cid sub = '_' ).
+       IF mapped_create_pr IS NOT INITIAL.
+         LOOP AT onlineorders INTO DATA(onlineorder1) WHERE OverallStatus = c_overall_status-new .
+           LOOP AT mapped_create_pr-purchaserequisition INTO DATA(purchaserequisition_details)   .
+             IF onlineorder1-OrderID = substring_before( val = purchaserequisition_details-%cid sub = '_' ).
 
-                APPEND VALUE #( cid                = purchaserequisition_details-%cid
-                                pid                = purchaserequisition_details-%pid
-                                order_uuid         = onlineorder1-OrderuuID  ) TO zbp_shopcarttp_###=>purchase_requisition_details .
-                DELETE ADJACENT DUPLICATES FROM zbp_shopcarttp_###=>purchase_requisition_details COMPARING pid.
-              ENDIF.
-            ENDLOOP.
-          ENDLOOP.
-        ENDIF.
-    ***End of EML Code Snippet********
+               APPEND VALUE #( cid                = purchaserequisition_details-%cid
+                               pid                = purchaserequisition_details-%pid
+                               order_uuid         = onlineorder1-OrderuuID  ) TO zbp_shopcarttp_###=>purchase_requisition_details .
+               DELETE ADJACENT DUPLICATES FROM zbp_shopcarttp_###=>purchase_requisition_details COMPARING pid.
+             ENDIF.
+           ENDLOOP.
+         ENDLOOP.
+       ENDIF.
+   ***End of EML Code Snippet********
 
-        MODIFY ENTITIES OF zr_shopcarttp_### IN LOCAL MODE
-          ENTITY ShoppingCart
-              UPDATE FIELDS ( OverallStatus )
-                WITH VALUE #( FOR key IN keys (
-                  OrderUUID = key-OrderUUID
-                  OverallStatus = c_overall_status-submitted
-              ) ).
+       MODIFY ENTITIES OF zr_shopcarttp_### IN LOCAL MODE
+         ENTITY ShoppingCart
+             UPDATE FIELDS ( OverallStatus )
+               WITH VALUE #( FOR key IN keys (
+                 OrderUUID = key-OrderUUID
+                 OverallStatus = c_overall_status-submitted
+             ) ).
 
-        "Read the changed data for action result
-        READ ENTITIES OF zr_shopcarttp_### IN LOCAL MODE
-          ENTITY ShoppingCart
-            ALL FIELDS WITH
-            CORRESPONDING #( keys )
-          RESULT DATA(result_read).
-        "return result entities
-        result = VALUE #( FOR result_order IN result_read ( %tky   = result_order-%tky
-                                                            %param = result_order ) ).
+       "Read the changed data for action result
+       READ ENTITIES OF zr_shopcarttp_### IN LOCAL MODE
+         ENTITY ShoppingCart
+           ALL FIELDS WITH
+           CORRESPONDING #( keys )
+         RESULT DATA(result_read).
+       "return result entities
+       result = VALUE #( FOR result_order IN result_read ( %tky   = result_order-%tky
+                                                           %param = result_order ) ).
 
-      ENDMETHOD.
+     ENDMETHOD.
 
-      METHOD checkpurchaserequisition.
-      ENDMETHOD.
+     METHOD checkpurchaserequisition.
+     ENDMETHOD.
 
-    ENDCLASS.
-    ```
+   ENDCLASS.
+   ```
 
    3. Save and activate.
 
-    >**HINT:** The option **internal** can be set before the action name to only provide an action for the same BO. An internal action can only be accessed from the business logic inside the business object implementation such as from a determination or from another action.
+   >**HINT:** The option **internal** can be set before the action name to only provide an action for the same BO. An internal action can only be accessed from the business logic inside the business object implementation such as from a determination or from another action.
 
    4. Go back to your behavior definition `ZR_SHOPCARTTP_###` and activate it again, if needed.
 

--- a/tutorials/abap-s4hanacloud-purchasereq-integrate-flp-tier1/abap-s4hanacloud-purchasereq-integrate-flp-tier1.md
+++ b/tutorials/abap-s4hanacloud-purchasereq-integrate-flp-tier1/abap-s4hanacloud-purchasereq-integrate-flp-tier1.md
@@ -92,7 +92,7 @@ In this step, you will create a business catalog. The SAP Fiori business catalog
 
       Select your transport request and description. Select the check mark.
 
-    > **Hint**: The business catalog has the naming convention `BC`.
+   > **Hint**: The business catalog has the naming convention `BC`.
 
   5. Click **Add Tiles/Target Mappings** and select **`Add Tiles/TMs to Selected Catalog`**.
 

--- a/tutorials/abap-s4hanacloud-purchasereq-integrate-flp/abap-s4hanacloud-purchasereq-integrate-flp.md
+++ b/tutorials/abap-s4hanacloud-purchasereq-integrate-flp/abap-s4hanacloud-purchasereq-integrate-flp.md
@@ -98,11 +98,11 @@ In this step, you will create a technical catalog. The technical catalog will be
  
       Click **Save**. 
 
-    > **Hint**: The technical catalog has the naming convention `TC`.
+  > **Hint**: The technical catalog has the naming convention `TC`.
 
-     Now the **SAP Fiori Launchpad Application Manager** opens.
+   Now the **SAP Fiori Launchpad Application Manager** opens.
 
-     The technical catalog contains the launchpad app descriptor item, which will be added in the next step.
+   The technical catalog contains the launchpad app descriptor item, which will be added in the next step.
 
 ### Create a launchpad app descriptor item
 
@@ -110,7 +110,7 @@ In this step, you will create a technical catalog. The technical catalog will be
 
       ![catalog](newx.png)
     
-    > **Hint:** The launchpad app descriptor item can be for e.g. an SAPUI5 Fiori app.
+   > **Hint:** The launchpad app descriptor item can be for e.g. an SAPUI5 Fiori app.
 
   2. Fill in the target application fields:
      - App Type: SAPUI5 Fiori App
@@ -157,7 +157,7 @@ In this step, you will create a business catalog. The SAP Fiori business catalog
 
       Select your transport request and description. Select the check mark.
 
-    > **Hint**: The technical catalog has the naming convention `BC`.
+   > **Hint**: The technical catalog has the naming convention `BC`.
 
   5. Click **Add Tiles/Target Mappings** and select **`Add Tiles/TMs to Selected Catalog`**.
 

--- a/tutorials/abap-s4hanacloud-purchasereq-replace-wrapper/abap-s4hanacloud-purchasereq-replace-wrapper.md
+++ b/tutorials/abap-s4hanacloud-purchasereq-replace-wrapper/abap-s4hanacloud-purchasereq-replace-wrapper.md
@@ -63,7 +63,6 @@ You just defined a new table type, which will be used in the behavior implementa
 
 Your global class should now look as follows:
 
-<!-- border -->
 ![Global Class](1-global-class.png)
 
 Save it. Do NOT activate it yet.
@@ -157,7 +156,6 @@ The `createpurchrqnbapisave` method handles the creation of a purchase requisiti
 
 The `createpurchrqnbapisave` method should now look like this:
 
-<!-- border -->
 ![Implementation Code](impl-createpurchrqnbapisave.png)
 
 You will now navigate to the `save_modified` method, remove the call to the BAPI wrapper and insert the following code snippet with an EML call to the released API:
@@ -193,7 +191,6 @@ As previously explained, the released API `I_PurchaserequisitionTP` uses late nu
 
 The `save_modified` method should now look as follows:
 
-<!-- border -->
 ![save_modified implementation](save_modified_new.png)
 
 Save and activate it.
@@ -204,7 +201,6 @@ As explained in a previous tutorial [Integrate the Wrapper into the Shopping Car
 
 You will now remove the `checkPurchaseRequisition` method: open the `lhc_shopcart` class of your behavior implementation and navigate to the `checkpurchaserequisiton` method. Comment it out:
 
-<!-- border -->
 ![Comment out checkpurchaserequisiton method implementation](impl_checkpurchaserequisition_new.png)
 
 Comment out the validation in the behavior definition, too:
@@ -217,14 +213,12 @@ Since you now removed the `checkpurchaserequisiton` method, no authorization che
 
 Open the behavior definition `ZR_SHOPCARTTP_###` and change to strict(2) mode:
 
-<!-- border -->
 ![Behavior Definition Strict 2](bdef-strict2.png)
 
 Save and activate it.
 
 Open the behavior definition `ZC_SHOPCARTTP_###` and change to strict(2) mode there as well:
 
-<!-- border -->
 ![Behavior Definition Strict 2](bdef-c-strict2.png)
 
 Save and activate it.
@@ -233,12 +227,10 @@ Save and activate it.
 
 In ADT, open the Service Binding `ZUI_SHOPCART_O4_###` and click on the **Preview** button to start a preview of the UI of your RAP BO. You will be prompted to login. Create a new entry and then click on the button **Create PR via BAPI in SAVE** to create the purchase requisition via released API:
 
-<!-- border -->
 ![Create PR - start](create-pr-1.png)
 
 The purchase requisition will be created:
 
-<!-- border -->
 ![Create PR - result](create-pr-2.png)
 
 ### Maintain Authorization Defaults
@@ -278,22 +270,18 @@ For simplicity and continuity, you will use the `Z_USER_###` user with the `ZR_S
 
 3. In this step switch to edit mode and click on `Object`-->`Add Objects (Manually)`. In the pop-up window add the needed authorization objects and click on `Continue`. The authorization objects will be added but you still need to maintain the relative Authorization Default Values (for more information, please refer to the Purchase Requisition API documentation). Do so and then save it. The warning, which is shown, indicates that Full authorization for authorization object `M_BANF_BSA` field `BSART` is granted. It can be ignored in the context of this tutorial. (For more explanation see the long text). The service binding should now look like this:
 
-    <!-- border -->
     ![Service Binding Authorizations](service-binding-auth.PNG)
 
 4. Start transaction `SU24` and select `SAP Gateway OData V4 Backend Service Group and Assignments` from the dropdown menu of the `Type of Application` field. In the `Object Name` field input your Service Binding name (`ZUI_SHOPCART_WRAPPER_O4_###`) and click on the `Execute` button. Switch to edit mode and click on the `SAP Data` icon (1), mark the needed authorization objects (2), and then click on `Copy SAP Data to SU24` icon (3) in the Maintenance Status for Authorization Objects tab. This will copy the authorization objects, but you still need to copy the authorization defaults values for each object.
 
-    <!-- border -->
     ![Maintain SU24 Data](su24-copy-sap-data.PNG)
   To do this, click on the `Synchronize with SAP data` icon (1) for all the authorization objects or click on the `Copy SAP Data to SU24` icon (2) in the `Authorization Default Values` tab.
 
-    <!-- border -->
     ![Maintain Authorization Default Values](su24-maintain-auth-default-values.PNG)
   Save it and select a suitable transport request (or create a new one if needed).
 
 5. Start transaction `PFCG`, open the role `ZR_SHOPCART_###` in Edit mode, navigate to the `Authorizations` tab and click on `Expert Mode for Profile Generation` and in the pop-up select `Read old status and merge with new data` and click on `execute`. You will see that all the authorization objects are automatically added and all the field values are set. Save (1) and then click on the `Generate` (2) icon to generate the authorization profile.
 
-    <!-- border -->
     ![Generate Profile](pfcg-profile-generation.PNG)
 
 Now the `Z_USER_###` user has the role assigned which contains the service binding and  the necessary authorizations to create a purchase requisition via the released API.

--- a/tutorials/abap-s4hcloud-procurement-po-customlogic-tracing/abap-s4hcloud-procurement-po-customlogic-tracing.md
+++ b/tutorials/abap-s4hcloud-procurement-po-customlogic-tracing/abap-s4hcloud-procurement-po-customlogic-tracing.md
@@ -43,19 +43,19 @@ Throughout this tutorial, the placeholder `###` or `000` is used. Always replace
 
 1. Open the app **Custom Fields**.
 
-    <!-- border -->![step1a-open-custom-fields](step1a-open-custom-fields.png)
+    ![step1a-open-custom-fields](step1a-open-custom-fields.png)
 
 2. Change to the **Custom Logic** tab, search for the `BAdI` implementation **`YY1_FILLHEADERCUSTOMFIELD_000`**.
 
-    <!-- border -->![Link text e.g., Destination screen](step1b-custom-fields-tabs.png)
+    ![Link text e.g., Destination screen](step1b-custom-fields-tabs.png)
 
 3. Open the **Details** screen (by choosing the arrow on the right).
 
-    <!-- border -->![step6b-badi-implementation-overview](step6b-badi-implementation-overview.png)
+    ![step6b-badi-implementation-overview](step6b-badi-implementation-overview.png)
 
 You can now see the Published Logic and Draft Logic, if they exist, relevant to the custom field.
 
-<!-- border -->![step1c-custom-logic-empty](step1c-custom-logic-empty.png)
+![step1c-custom-logic-empty](step1c-custom-logic-empty.png)
 
 
 ### Add custom logic
@@ -65,14 +65,14 @@ You can now see the Published Logic and Draft Logic, if they exist, relevant to 
 2. In the custom logic for the field **`yy1_zhdrprnt2_pdh_000`**, copy the following code.
 This code will copy the content from a standard field, `purchaseorder-supplyingplant` into the custom field, **`yy1_zhdrprnt2_pdh_000`**, where `supplyingplant` is filled.
 
-    ```ABAP
-    IF purchaseorder-supplyingplant is not initial.
-    purchaseorderchange-yy1_zhdrprnt2_pdh_000 = purchaseorder-supplyingplant.
-    endif.
+   ```ABAP
+   IF purchaseorder-supplyingplant is not initial.
+   purchaseorderchange-yy1_zhdrprnt2_pdh_000 = purchaseorder-supplyingplant.
+   endif.
 
-    ```
+   ```
 
-    <!-- border -->![step2a-add-custom-logic](step2a-add-custom-logic.png)
+    ![step2a-add-custom-logic](step2a-add-custom-logic.png)
 
 3. Save and publish your custom code.
 
@@ -84,7 +84,7 @@ You are now ready to trace the effects of your custom code when a purchase order
 
 1. Open the app **Custom Logic Tracing** and choose **Start Trace**.
 
-    <!-- border -->![step1a-start-trace](step1a-start-trace.png)
+    ![step1a-start-trace](step1a-start-trace.png)
 
 2. Enter the following information, remembering to change the placeholder to your group number or initials:
 
@@ -95,7 +95,7 @@ You are now ready to trace the effects of your custom code when a purchase order
     |  Stored until    | *future date in the format `dd.mm.yyyy`*
     |  Lifetime          | **15**
 
-    <!-- border -->![step1b-start-trace-details](step1b-start-trace-details.png)
+    ![step1b-start-trace-details](step1b-start-trace-details.png)
 
 
 
@@ -105,19 +105,19 @@ You are now ready to trace the effects of your custom code when a purchase order
 
 1. Open **Create Purchase Order - Advanced**.
 
-    <!-- border -->![step4a-create-po](step4a-create-po.png)
+    ![step4a-create-po](step4a-create-po.png)
 
 2. In the top header, change the Order Type to **Stock Transport Order** and the Supplying Plant to **1010**.
 
-    <!-- border -->![step4b-change-to-stock-transport-order](step4b-change-to-stock-transport-order.png)
+    ![step4b-change-to-stock-transport-order](step4b-change-to-stock-transport-order.png)
 
 3. Enter the **Supplying Plant**, **1010**    
 
-    <!-- border -->![step4c-supplying-plant](step4c-supplying-plant.png)
+    ![step4c-supplying-plant](step4c-supplying-plant.png)
 
 4. In the header section, go to the **Custom Fields** tab, check that the custom field **ZPOHDRPRINT2** now contains the value **1010**.
 
-    <!-- border -->![step4a-create-po-custom-field](step4a-create-po-custom-field.png)
+    ![step4a-create-po-custom-field](step4a-create-po-custom-field.png)
 
 5. On the **Org Data** tab, enter the following:
 
@@ -129,7 +129,7 @@ You are now ready to trace the effects of your custom code when a purchase order
 
     > If you check the custom field **`YY1_ZHDRPRNT2_PDH_000`**, it is now filled with the same value as Supplying Plant, **1010**.
 
-    <!-- border -->![step2c-fill-org-data](step2c-fill-org-data.png)
+    ![step2c-fill-org-data](step2c-fill-org-data.png)
 
 6. In the **Item Overview** section, enter the following. Ignore any warnings.
 
@@ -140,15 +140,15 @@ You are now ready to trace the effects of your custom code when a purchase order
     |  Delivery Date     | *future date in the format `dd.mm.yyyy`*
     |  Plant           | **1010**
 
-      <!-- border -->![step4d-fill-item-overview-material](step4d-fill-item-overview-material.png)
+      ![step4d-fill-item-overview-material](step4d-fill-item-overview-material.png)
 
     > The other fields - Material Group, Plant Storage Location - should be filled automatically.
 
-    <!-- border -->![step2d-fill-item-overview](step2d-fill-item-overview.png)
+    ![step2d-fill-item-overview](step2d-fill-item-overview.png)
 
 7. Choose **Save**.
 
-    <!-- border -->![step4e-note-stock-transport-number](step4e-note-stock-transport-number.png)
+    ![step4e-note-stock-transport-number](step4e-note-stock-transport-number.png)
 
 
 
@@ -156,17 +156,17 @@ You are now ready to trace the effects of your custom code when a purchase order
 
 1. Choose **Finish trace**.
 
-    <!-- border -->![step5a-finish-trace](step5a-finish-trace.png)
+    ![step5a-finish-trace](step5a-finish-trace.png)
 
 2. Open the trace. In **Trace Hierarchy**, choose the last call of `BAdI` implementation `YY1_FILLHEADERCUSTOMFIELD_000`.
 (This is necessary because the `BAdI` implementation is called several times.)
 Then choose the parameter **Purchase Order**.
 
-    <!-- border -->![step5b-choose-purchase-order](step5b-choose-purchase-order.png)
+    ![step5b-choose-purchase-order](step5b-choose-purchase-order.png)
 
 3. Scroll right down to the field **`YY1_ZHDRPRNT2_PDH_000`**. Check that its value = **1010**.
 
-    <!-- border -->![step5c-choose-custom-field](step5c-choose-custom-field.png)
+    ![step5c-choose-custom-field](step5c-choose-custom-field.png)
 
 
 

--- a/tutorials/abap-s4hcloud-procurement-po-debugging/abap-s4hcloud-procurement-po-debugging.md
+++ b/tutorials/abap-s4hcloud-procurement-po-debugging/abap-s4hcloud-procurement-po-debugging.md
@@ -33,7 +33,6 @@ Throughout this tutorial, objects name include a suffix, such as **`###`**. Alwa
 > The administrator receives an welcome e-mail after provisioning. This e-mail includes the system URL. By removing `/ui` you can log into the SAP S/4HANA Cloud ABAP Environment system. Further information can be found [Developer Extensibility: Connect to the ABAP System](https://help.sap.com/docs/SAP_S4HANA_CLOUD/6aa39f1ac05441e5a23f484f31e477e7/4b962c243a3342189f8af460cc444883.html?locale=en-US).
 
 
-<!-- border -->
 ![step0-overview-debug](step0-overview-debug.png)
 
 ---
@@ -45,7 +44,6 @@ Throughout this tutorial, objects name include a suffix, such as **`###`**. Alwa
 
 2. Choose **Add `BAdI` implementation**
 
-    <!-- border -->
     ![step1a-add-badi-impl](step1a-add-badi-impl.png)
 
 
@@ -58,7 +56,6 @@ Throughout this tutorial, objects name include a suffix, such as **`###`**. Alwa
 
 Your `BAdI` implementation appears in a new editor.
 
-<!-- border -->
 ![step1c-badi-impl-editor](step1c-badi-impl-editor.png)
 
 Ignore the error. You will fix this in the next step.
@@ -77,21 +74,21 @@ Ignore the error. You will fix this in the next step.
 
     The class appears in a new editor with skeleton code.
 
-    ```ABAP
-    CLASS ZIC_PR_ITEM DEFINITION
-      PUBLIC
-      FINAL
-      CREATE PUBLIC .
+   ```ABAP
+   CLASS ZIC_PR_ITEM DEFINITION
+     PUBLIC
+     FINAL
+     CREATE PUBLIC .
 
-      PUBLIC SECTION.
+     PUBLIC SECTION.
 
-        INTERFACES if_badi_interface .
-        INTERFACES if_mm_pur_s4_pr_modify_item .
-      PROTECTED SECTION.
-      PRIVATE SECTION.
-    ENDCLASS
+       INTERFACES if_badi_interface .
+       INTERFACES if_mm_pur_s4_pr_modify_item .
+     PROTECTED SECTION.
+     PRIVATE SECTION.
+   ENDCLASS
 
-    ```
+   ```
 
 4. Format, save, and activate the class ( **`Shift+F1, Ctrl+S, Ctrl+F3`** ).
 
@@ -132,7 +129,6 @@ The error will disappear.
 
 3. Check that yours is the implementation that will be called:
 
-    <!-- border -->
     ![step5d-impl-called](step5d-impl-called.png)
 
 
@@ -141,11 +137,9 @@ First you will add the relevant view to your ABAP perspective.
 
 1. In ADT, search for the view **ABAP Cross Trace** using the magnifying glass; then add it by clicking it.
 
-    <!-- border -->
     ![step4a-add-cross-trace-view](step4a-add-cross-trace-view.png)
 
 2. The view appears. Now you will create the trace configuration. Select your system and choose **Create Configuration...** from the context menu.
-    <!-- border -->
     ![step4b-create-configuration](step4b-create-configuration.png)
 
 3. Enter the following information, then choose **OK**.
@@ -159,12 +153,10 @@ First you will add the relevant view to your ABAP perspective.
     | Component | *Choose **`ABAP-BAdIs > BAdI Calls`**; deselect all other traces.
     | Trace Level | (4) Verbose 
 
-    <!-- border -->
     ![step4d-trace-config](step4d-trace-config.png)
 
 The active trace appears.
 
-  <!-- border -->
   ![step4e-trace-active](step4e-trace-active.png)
 
 
@@ -173,33 +165,28 @@ You will now execute the app while the trace is active.
 
 1. In the app **Manage Purchase Requisitions - Professional**, choose an existing purchase requisition and navigate to the detail, then to the **Items** tab.
 
-    <!-- border -->
     ![step5a-pur-req-items](step5a-pur-req-items.png)
 
 2. Choose **Edit**.
 
 3. Trigger the `BAdI`, e.g. by changing the quantity; notice the message ID, **`BAdI`**.
 
-    <!-- border -->   
     ![step5c-error](step5c-error.png)
 
 
 ### Analyze BAdI call in ABAP Cross Trace
 1. Back in ADT, deactivate the trace from the context menu, then choose **Refresh**.
 
-    <!-- border -->
     ![step5d-deactivate-trace](step5d-deactivate-trace.png)
 
 2. In the tab **Trace Results**, navigate through the trace records; filter by **`MODIFY_ITEM`**.
 
 3. Note the relevant `BAdI` implementation class associated with **`IF_MM_PUR_S4_PR_MODIFY_ITEM~MODIFY_ITEM`** is **`ZIC_PR_ITEM`**; note the **`MESSAGEID = BAdI`**.
 
-    <!-- border -->
     ![step6b-find-messageId](step6b-find-messageId.png)
 
 You can now edit this class in ADT.
 
-<!-- border -->
 ![step6c-class-in-adt](step6c-class-in-adt.png)
 
 
@@ -209,7 +196,6 @@ Now, you can check the developer extension (`BAdI`) using ABAP Debugger.
 
 1. In the backend system, search for your implementing class **`ZIC_PR_ITEM`**.
 
-    <!-- border -->
     ![step4a-find-class](step4a-find-class.png)
 
 2. Set a breakpoint. 
@@ -217,27 +203,22 @@ Now, you can check the developer extension (`BAdI`) using ABAP Debugger.
     Position the cursor within the ruler (left bar) of the source editor at the line 
     `IF purchaserequisition-PURCHASINGDOCUMENTTYPE EQ 'NB'.`, then choose **Toggle Breakpoint** from the context menu.
 
-    <!-- border -->
     ![step4b-set-breakpoint](step4b-set-breakpoint.png)
 
 3. Go back to the **Manage Purchase Requisitions - Professional** app and create a new purchase requisition (PR).
 
-    <!-- border -->
     ![step4c-pr-tile](step4c-pr-tile.png)
 
 4. Now that the breakpoint is set, the system suggests you change to the **ABAP Debugger** perspective. Choose **Switch**.
 
-    <!-- border -->
     ![step5-switch-perspective](step5-switch-perspective.png)
 
 5. The perspective appears, showing: The call stack; your code; any breakpoint(s) you have set.
 
-    <!-- border -->
     ![step7d-debugger-perspective](step7d-debugger-perspective.png)
 
 6. You can now step through the code as normal (using F5, F6, F7). When you are done, choose **Terminate (F8)** from the main toolbar. You will return to the **ABAP** perspective.
 
-    <!-- border -->
     ![step7c-terminate](step7c-terminate.png)   
 
 
@@ -246,19 +227,16 @@ Once set, this condition is evaluated at runtime whenever the source code positi
 
 1. Place your cursor on your breakpoint and choose **Breakpoint Properties** from the context menu.
 
-    <!-- border -->
     ![step8a-breakpoint-properties](step8a-breakpoint-properties.png)
 
 2. Add the condition `PURCHASEREQUISITIONITEM~ORDEREDQUANTITY=9`, then choose **Apply**.
 
-    <!-- border -->
     ![step8b-breakpoint-condition](step8b-breakpoint-condition.png)
 
 3. Again, run the app **Manage Purchase Requisitions - Professional**, create a new PR, switch to the Debugger when prompted.
 
 The Debugger has stopped where the **`ORDEREDQUANTITY`** = 9.
 
-<!-- border -->
 ![step8c-condition-9](step8c-condition-9.png)
 
 
@@ -269,15 +247,12 @@ Once a `watchpoint` is set, the Debugger stops as soon as the value of a watched
 
 1. In the class **`ZIC_PR_ITEM`**, position the cursor on the relevant field.
 
-    <!-- border -->
     ![step9a-set-watchpoint](step9a-set-watchpoint.png)
 
-    <!-- border -->
     ![step9b-watchpoint-created](step9b-watchpoint-created.png)
 
 2. To set a condition for the `watchpoint`: open the **Breakpoints** view in the **Debugger** perspective, select the `watchpoint`, then enter a condition.
 
-    <!-- border -->
     ![step9c-set-watchpoint-condition](step9c-set-watchpoint-condition.png)
 
 The ABAP Debugger stops as soon as the value of the variable is changed after a debug step **and** the specified condition for the `watchpoint` is fulfilled.   

--- a/tutorials/abap-websocket-rfc/abap-websocket-rfc.md
+++ b/tutorials/abap-websocket-rfc/abap-websocket-rfc.md
@@ -50,19 +50,19 @@ First, you have to create a communication scenario based on a remote-enabled fun
     - Description: **`RFM for WebSocket RFC`**
 5. Paste the following code.
 
-    ```ABAP
-        FUNCTION Z_RFM_XXX
+   ```ABAP
+       FUNCTION Z_RFM_XXX
 
-          IMPORTING
-            VALUE(input) TYPE string
-          EXPORTING
-            VALUE(output) TYPE string.
-        
-          output = input && ' How are you?'.
+         IMPORTING
+           VALUE(input) TYPE string
+         EXPORTING
+           VALUE(output) TYPE string.
+       
+         output = input && ' How are you?'.
 
-        ENDFUNCTION.
+       ENDFUNCTION.
 
-    ```
+   ```
 
 6. Save and activate the function module.
 
@@ -152,40 +152,40 @@ The connection test returns a ping result.
     - Description: **`WebSocket RFC Call`**
 3. Paste the following code.
 
-    ```ABAP
+   ```ABAP
 
-      CLASS z_ws_rfc_call_xxx DEFINITION
-        PUBLIC
-        FINAL
-        CREATE PUBLIC .
+     CLASS z_ws_rfc_call_xxx DEFINITION
+       PUBLIC
+       FINAL
+       CREATE PUBLIC .
 
-        PUBLIC SECTION.
+       PUBLIC SECTION.
 
-          INTERFACES if_oo_adt_classrun .
-        PROTECTED SECTION.
-        PRIVATE SECTION.
-      ENDCLASS.
+         INTERFACES if_oo_adt_classrun .
+       PROTECTED SECTION.
+       PRIVATE SECTION.
+     ENDCLASS.
 
-      CLASS z_ws_rfc_call_xxx IMPLEMENTATION.
+     CLASS z_ws_rfc_call_xxx IMPLEMENTATION.
 
-        METHOD if_oo_adt_classrun~main.
+       METHOD if_oo_adt_classrun~main.
 
-          DATA lv_output TYPE string.
-          DATA lv_input TYPE string VALUE 'Hello world!'.
+         DATA lv_output TYPE string.
+         DATA lv_input TYPE string VALUE 'Hello world!'.
 
-          CALL FUNCTION 'Z_RFM_XXX' DESTINATION 'Z_WSRFCDEST_XXX'
-            EXPORTING
-              input  = lv_input
-            IMPORTING
-              output = lv_output.
+         CALL FUNCTION 'Z_RFM_XXX' DESTINATION 'Z_WSRFCDEST_XXX'
+           EXPORTING
+             input  = lv_input
+           IMPORTING
+             output = lv_output.
 
 
-          out->write( lv_output ).
+         out->write( lv_output ).
 
-        ENDMETHOD.
-      ENDCLASS.
+       ENDMETHOD.
+     ENDCLASS.
 
-    ```
+   ```
 
 4. Save and activate the class.
 5. Choose **Run > Run AS > ABAP Application (Console)**.

--- a/tutorials/ws-local-configuration/ws-local-configuration.md
+++ b/tutorials/ws-local-configuration/ws-local-configuration.md
@@ -118,15 +118,15 @@ A provider system describes the parameters and access to a system that contains 
 
     - Copy the highlighted part to /sap/bc/:
 
-        <!-- border -->![System URL](lc1.png)
+        ![System URL](lc1.png)
 
     - Go back to the SOAMANAGER of system A. Add the part from /sap/bc of the placeholder URL to the part you have copied in step 4. Add the corresponding client of system B.
 
-        <!-- border -->![Access URL for WSIL](lc2.png)
+        ![Access URL for WSIL](lc2.png)
 
     - In this example, this results in:
 
-        <!-- border -->![WSIL URL](lc8.png)
+        ![WSIL URL](lc8.png)
 
 6. Enter the credentials of a user in system B with permission to display the WSIL.
 
@@ -134,7 +134,7 @@ A provider system describes the parameters and access to a system that contains 
 
 8. Your settings should look like this:
 
-    <!-- border -->![Services Registry settingsL](lc9.png)
+    ![Services Registry settingsL](lc9.png)
 
 9. Choose **Next**.
 
@@ -174,7 +174,7 @@ In system B, the service definitions are assigned to profiles which result in en
 
 5. Choose **Assign Profiles**, choose your profile from the list, and click **Assign Profiles**.
 
-    <!-- border -->![Assign profile in consumer](lc5.png)
+    ![Assign profile in consumer](lc5.png)
 
 6. Skip step **Service Groups**.
 7. Go to step **Logon Data Assignment** and choose **Finish**.
@@ -205,13 +205,13 @@ On consumer side, it is specified which consumer proxies need to be configured f
 
 8. Choose your provider system from the list. Ignore this **Is Configured** checkbox and choose **Assign to Service Group**.
 
-    <!-- border -->![Service Group Assignment](lc3.png)
+    ![Service Group Assignment](lc3.png)
 
 9. Choose **Next**.
 
 10. In the step **Logon Data Assignment**, choose your logon data from the list.
 
-    <!-- border -->![Logon Data](lc4.png)
+    ![Logon Data](lc4.png)
 
 11. Choose **Finish**.
 12. Activate the integration scenario by choosing **Yes** in the pop-up window.
@@ -235,13 +235,13 @@ To apply your profiles and business scenarios, you have to process the pending t
 
 2. Search for your consumer proxy. It is named like the service definition with the prefix `CO_`. You can also search for your service definition and choose the consumer proxy from the search results. In this case, it is `CO_SRT_TEST_PROVIDER`.
 
-    <!-- border -->![Consumer proxy](lc6.png)
+    ![Consumer proxy](lc6.png)
 
 3. Click on the consumer proxy.
 
 4. Copy the name of the logical port. In the column **Creation Type**, you can see that the logical port is created based on your profile.
 
-    <!-- border -->![Logical port of consumer proxy](lc7.png)
+    ![Logical port of consumer proxy](lc7.png)
 
 5. Logon to system A in SAP GUI.
 
@@ -257,7 +257,7 @@ To apply your profiles and business scenarios, you have to process the pending t
 
 11. Choose **Execute** (F8). The response opens. In this case, the result should look like this:
 
-    <!-- border -->![Logical port of consumer proxy](lc10.png)
+    ![Logical port of consumer proxy](lc10.png)
 
 
 ### Test yourself


### PR DESCRIPTION
Automated conservative, idempotent fixes for malformed-markdown patterns that the
tutorials-ims render pipeline currently patches in flight (sap-tutorials/tutorials-ims#1963).


Classes fixed: list-continuation-fence, list-continuation-prose, image-directive-comment

Tutorials (12):
- `tutorials/abap-s4hanacloud-procurement-purchasereq-shop/abap-s4hanacloud-procurement-purchasereq-shop.md`
- `tutorials/abap-s4hanacloud-purchasereq-deploy-ui/abap-s4hanacloud-purchasereq-deploy-ui.md`
- `tutorials/abap-s4hanacloud-purchasereq-deploy-ui-tier1/abap-s4hanacloud-purchasereq-deploy-ui-tier1.md`
- `tutorials/abap-s4hanacloud-purchasereq-enhance-shop/abap-s4hanacloud-purchasereq-enhance-shop.md`
- `tutorials/abap-s4hanacloud-purchasereq-integrate-api/abap-s4hanacloud-purchasereq-integrate-api.md`
- `tutorials/abap-s4hanacloud-purchasereq-integrate-flp/abap-s4hanacloud-purchasereq-integrate-flp.md`
- `tutorials/abap-s4hanacloud-purchasereq-integrate-flp-tier1/abap-s4hanacloud-purchasereq-integrate-flp-tier1.md`
- `tutorials/abap-s4hanacloud-purchasereq-replace-wrapper/abap-s4hanacloud-purchasereq-replace-wrapper.md`
- `tutorials/abap-s4hcloud-procurement-po-customlogic-tracing/abap-s4hcloud-procurement-po-customlogic-tracing.md`
- `tutorials/abap-s4hcloud-procurement-po-debugging/abap-s4hcloud-procurement-po-debugging.md`
- `tutorials/abap-websocket-rfc/abap-websocket-rfc.md`
- `tutorials/ws-local-configuration/ws-local-configuration.md`

Each change is idempotent and verified by a golden-render gate: composing the original
vs. fixed source through the pipeline yields byte-identical steps/body/intro.

🤖 Generated with Claude Code